### PR TITLE
Dynamic Disk partitions

### DIFF
--- a/provisioning/lib/constants
+++ b/provisioning/lib/constants
@@ -19,3 +19,8 @@ logfile="~/openstack_provision.log"
 no_install=false
 action="provision"
 provision_components="openshift"
+default_disk_path_docker="/dev/vdb"
+default_disk_path_ose="/dev/vdb"
+default_part_size_ose="2000"
+default_volume_size="10"
+

--- a/provisioning/lib/constants
+++ b/provisioning/lib/constants
@@ -19,8 +19,7 @@ logfile="~/openstack_provision.log"
 no_install=false
 action="provision"
 provision_components="openshift"
-default_disk_path_docker="/dev/vdb"
-default_disk_path_ose="/dev/vdb"
-default_part_size_ose="2000"
-default_volume_size="10"
+storage_disk_volume="/dev/vdb"
+storage_volume_size="10"
+storage_size_ose="2"
 

--- a/provisioning/lib/helpers
+++ b/provisioning/lib/helpers
@@ -89,3 +89,95 @@ process_template() {
 
   echo "$output"
 }
+
+# Usage: partition_disk <path_to_disk> <partition_size>
+#  e.g.: partition_disk /dev/vdb 2000 <-- creates a 2000MB partition on /dev/vdb
+function partition_disk() {
+  root_disk=${1}
+  part_size=${2}
+
+  part_label=`fdisk -l ${root_disk} | sed -n 's/Disk label type: \(.*\)/\1/p'`
+  [ "${part_label}" != "dos" ] && parted ${root_disk} --script -- mklabel msdos
+
+  end_idx=`parted -m /dev/vdb print | tail -n 1 | awk -F: '{ print $1 }'`
+  [ ${end_idx} -gt 4 ] && return 1
+
+  part_start=`parted -m ${root_disk} unit MB print | tail -n 1 | awk -F: '{ print $3 }' | sed -ne 's/^\([0-9]*\)MB$/\1/p'`
+  [ -z "${part_start}" ] && part_start=0
+
+  part_end=$(($part_start + $part_size))
+  [ "${part_size}" == "-1" ] && part_end='-1' # Use the rest of the disk ...
+
+  parted ${root_disk} --script -- mkpart primary ${part_start} ${part_end}
+  [ $? -ne 0 ] && return 1 
+
+  partprobe
+
+  part_idx=`parted -m /dev/vdb print | tail -n 1 | awk -F: '{ print $1 }'`
+
+  echo "${root_disk}${part_idx}"
+  return 0
+}
+
+setup_docker_storage() {
+  disk_path=${1}
+
+  # Install and configure docker
+  yum -y install docker &>/dev/null || error_out "Failed to install package docker"
+  # sed -i "s/OPTIONS='--selinux-enabled'/OPTIONS='--selinux-enabled --insecure-registry 172.30.0.0\/16'/" /etc/sysconfig/docker
+
+  vgdisplay vg-docker &>/dev/null
+  vg_rc=$?
+
+  if [ ${vg_rc} -eq 0 ]; then
+    echo "docker storage already configured!"
+    return 0
+  fi
+
+  disk_part=`partition_disk ${disk_path} '-1'`
+  [ $? -ne 0 ] && return 1
+
+  pvcreate ${disk_part}
+  vgcreate vg-docker ${disk_part}
+
+  cat << EOF > /etc/sysconfig/docker-storage-setup
+VG=vg-docker
+SETUP_LVM_THIN_POOL=yes
+EOF
+
+  # Let docker setup the storage based on the above config file
+  docker-storage-setup
+
+  return 0
+}
+
+setup_openshift_storage() {
+  disk_path=${1}
+  part_size=${2}
+
+  vgdisplay vg-openshift &>/dev/null
+  vg_rc=$?
+
+  if [ ${vg_rc} -eq 0 ]; then
+    echo "openshift storage already configured!"
+    return 0
+  fi
+
+  disk_part=`partition_disk ${disk_path} ${part_size}`
+  [ $? -ne 0 ] && return 1
+
+  # Create LVM and set up /var/lib/openshift
+  pvcreate ${disk_part}
+  vgcreate vg-openshift ${disk_part}
+  lvcreate -l 100%FREE -n lv-ose vg-openshift
+
+  mkfs.xfs -q -f /dev/vg-openshift/lv-ose
+
+  mkdir -p /var/lib/openshift
+  echo "/dev/vg-openshift/lv-ose        /var/lib/openshift              xfs defaults 0 0" >> /etc/fstab
+
+  mount -a
+
+  return 0
+}
+

--- a/provisioning/lib/helpers
+++ b/provisioning/lib/helpers
@@ -99,7 +99,7 @@ function partition_disk() {
   part_label=`fdisk -l ${root_disk} | sed -n 's/Disk label type: \(.*\)/\1/p'`
   [ "${part_label}" != "dos" ] && parted ${root_disk} --script -- mklabel msdos
 
-  part_start=`parted -m ${root_disk} unit GB print | tail -n 1 | awk -F: '{ print $3 }' | sed -ne 's/^\([0-9]*\)GB$/\1/p'`
+  part_start=`parted -m ${root_disk} unit MB print | tail -n 1 | awk -F: '{ print $3 }' | sed -ne 's/^\([0-9]*\)MB$/\1/p'`
   [ -z "${part_start}" ] && part_start=0
 
   # If we do indeed have some partitions already configured, check to see that we're less than
@@ -112,10 +112,11 @@ function partition_disk() {
   if [ "${part_size}" == "-1" ]; then
     part_end='-1' # Use the rest of the disk ...
   else
-    part_end=$(($part_start + $part_size))
+    # Multiple by 1000 to make it GB (note that parted uses MB (1000) and not MiB (1024))
+    part_end=$(($part_start + $part_size * 1000))
   fi
 
-  parted ${root_disk} --script -- mkpart primary "${part_start}GB" "${part_end}GB"
+  parted ${root_disk} --script -- mkpart primary "${part_start}MB" "${part_end}MB"
   [ $? -ne 0 ] && return 1 
 
   partprobe

--- a/provisioning/lib/helpers
+++ b/provisioning/lib/helpers
@@ -99,21 +99,28 @@ function partition_disk() {
   part_label=`fdisk -l ${root_disk} | sed -n 's/Disk label type: \(.*\)/\1/p'`
   [ "${part_label}" != "dos" ] && parted ${root_disk} --script -- mklabel msdos
 
-  end_idx=`parted -m /dev/vdb print | tail -n 1 | awk -F: '{ print $1 }'`
-  [ ${end_idx} -gt 4 ] && return 1
-
   part_start=`parted -m ${root_disk} unit MB print | tail -n 1 | awk -F: '{ print $3 }' | sed -ne 's/^\([0-9]*\)MB$/\1/p'`
   [ -z "${part_start}" ] && part_start=0
 
-  part_end=$(($part_start + $part_size))
-  [ "${part_size}" == "-1" ] && part_end='-1' # Use the rest of the disk ...
+  # If we do indeed have some partitions already configured, check to see that we're less than
+  # 4 primary - can only handle up to 4 primary partitions for now...
+  if [ ${part_start} -ne 0 ]; then 
+    end_idx=`parted -m ${root_disk} print | tail -n 1 | awk -F: '{ print $1 }'`
+    [ ${end_idx} -gt 4 ] && return 1
+  fi
+
+  if [ "${part_size}" == "-1" ]; then
+    part_end='-1' # Use the rest of the disk ...
+  else
+    part_end=$(($part_start + $part_size))
+  fi
 
   parted ${root_disk} --script -- mkpart primary ${part_start} ${part_end}
   [ $? -ne 0 ] && return 1 
 
   partprobe
 
-  part_idx=`parted -m /dev/vdb print | tail -n 1 | awk -F: '{ print $1 }'`
+  part_idx=`parted -m ${root_disk} print | tail -n 1 | awk -F: '{ print $1 }'`
 
   echo "${root_disk}${part_idx}"
   return 0

--- a/provisioning/lib/helpers
+++ b/provisioning/lib/helpers
@@ -91,7 +91,7 @@ process_template() {
 }
 
 # Usage: partition_disk <path_to_disk> <partition_size>
-#  e.g.: partition_disk /dev/vdb 2000 <-- creates a 2000MB partition on /dev/vdb
+#  e.g.: partition_disk /dev/vdb 2 <-- creates a 2GB partition on /dev/vdb
 function partition_disk() {
   root_disk=${1}
   part_size=${2}
@@ -99,7 +99,7 @@ function partition_disk() {
   part_label=`fdisk -l ${root_disk} | sed -n 's/Disk label type: \(.*\)/\1/p'`
   [ "${part_label}" != "dos" ] && parted ${root_disk} --script -- mklabel msdos
 
-  part_start=`parted -m ${root_disk} unit MB print | tail -n 1 | awk -F: '{ print $3 }' | sed -ne 's/^\([0-9]*\)MB$/\1/p'`
+  part_start=`parted -m ${root_disk} unit GB print | tail -n 1 | awk -F: '{ print $3 }' | sed -ne 's/^\([0-9]*\)GB$/\1/p'`
   [ -z "${part_start}" ] && part_start=0
 
   # If we do indeed have some partitions already configured, check to see that we're less than
@@ -115,7 +115,7 @@ function partition_disk() {
     part_end=$(($part_start + $part_size))
   fi
 
-  parted ${root_disk} --script -- mkpart primary ${part_start} ${part_end}
+  parted ${root_disk} --script -- mkpart primary "${part_start}GB" "${part_end}GB"
   [ $? -ne 0 ] && return 1 
 
   partprobe

--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -121,11 +121,11 @@ setup_training_repo() {
 }
 
 setup_storage() {
-  setup_openshift_storage ${OPENSHIFT_DISK_PATH_OSE} ${OPENSHIFT_PART_SIZE_OSE}
+  setup_openshift_storage ${OPENSHIFT_STORAGE_DISK_VOLUME} ${OPENSHIFT_STORAGE_SIZE_OSE}
   [ $? -eq 0 ] || error_out "Could not setup openshift storage" ${ERROR_CODE_STORAGE_FAILURE}
 
   # Always run the docker storage setup last as it will use what's left of the disk
-  setup_docker_storage ${OPENSHIFT_DISK_PATH_DOCKER}
+  setup_docker_storage ${OPENSHIFT_STORAGE_DISK_VOLUME}
   [ $? -eq 0 ] || error_out "Could not setup docker storage" ${ERROR_CODE_STORAGE_FAILURE}
 
   return 0
@@ -133,7 +133,7 @@ setup_storage() {
 
 setup_storage_on_all_hosts() {
   for host in ${MASTER_HOSTNAME} ${NODE_HOSTNAMES//,/ }; do
-    ${SSH_CMD} root@${host} "$(typeset -f); $(typeset -p OPENSHIFT_DISK_PATH_OSE); $(typeset -p OPENSHIFT_PART_SIZE_OSE); $(typeset -p OPENSHIFT_DISK_PATH_DOCKER); setup_storage"
+    ${SSH_CMD} root@${host} "$(typeset -f); $(typeset -p OPENSHIFT_STORAGE_DISK_VOLUME); $(typeset -p OPENSHIFT_STORAGE_SIZE_OSE); setup_storage"
   done
 }
 
@@ -321,9 +321,8 @@ OPENSHIFT_USERS=${CONF_OPENSHIFT_USERS:=$openshift_users}
 OPENSHIFT_BASE_DOMAIN=${CONF_OPENSHIFT_BASE_DOMAIN:=$openshift_base_domain}
 OPENSHIFT_MASTER_CONFIG=$openshift_master_config
 OPENSHIFT_ZONES=$openshift_zones
-OPENSHIFT_DISK_PATH_DOCKER=${CONF_DISK_PATH_DOCKER:=$default_disk_path_docker}
-OPENSHIFT_DISK_PATH_OSE=${CONF_DISK_PATH_OSE:=$default_disk_path_ose}
-OPENSHIFT_PART_SIZE_OSE=${CONF_PART_SIZE_OSE:=$default_part_size_ose}
+OPENSHIFT_STORAGE_DISK_VOLUME=${CONF_STORAGE_DISK_VOLUME:=$storage_disk_volume}
+OPENSHIFT_STORAGE_SIZE_OSE=${CONF_STORAGE_SIZE_OSE:=$storage_size_ose}
 
 # Begin installation phases
 process_actions ${ACTIONS?"Missing argument -a or --action"}

--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -121,11 +121,11 @@ setup_training_repo() {
 }
 
 setup_storage() {
-  setup_openshift_storage ${OPENSHIFT_DISK_PART_OSE} ${OPENSHIFT_PART_SIZE_OSE}
+  setup_openshift_storage ${OPENSHIFT_DISK_PATH_OSE} ${OPENSHIFT_PART_SIZE_OSE}
   [ $? -eq 0 ] || error_out "Could not setup openshift storage" ${ERROR_CODE_STORAGE_FAILURE}
 
   # Always run the docker storage setup last as it will use what's left of the disk
-  setup_docker_storage ${OPENSHIFT_DISK_PART_DOCKER}
+  setup_docker_storage ${OPENSHIFT_DISK_PATH_DOCKER}
   [ $? -eq 0 ] || error_out "Could not setup docker storage" ${ERROR_CODE_STORAGE_FAILURE}
 
   return 0
@@ -133,7 +133,7 @@ setup_storage() {
 
 setup_storage_on_all_hosts() {
   for host in ${MASTER_HOSTNAME} ${NODE_HOSTNAMES//,/ }; do
-    ${SSH_CMD} root@${host} "$(typeset -f); setup_storage"
+    ${SSH_CMD} root@${host} "$(typeset -f); $(typeset -p OPENSHIFT_DISK_PATH_OSE); $(typeset -p OPENSHIFT_PART_SIZE_OSE); $(typeset -p OPENSHIFT_DISK_PATH_DOCKER); setup_storage"
   done
 }
 

--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -121,59 +121,12 @@ setup_training_repo() {
 }
 
 setup_storage() {
-  # Install and configure docker
-  yum -y install docker &>/dev/null || error_out "Failed to install package docker"
-#  sed -i "s/OPTIONS='--selinux-enabled'/OPTIONS='--selinux-enabled --insecure-registry 172.30.0.0\/16'/" /etc/sysconfig/docker
+  setup_openshift_storage ${OPENSHIFT_DISK_PART_OSE} ${OPENSHIFT_PART_SIZE_OSE}
+  [ $? -eq 0 ] || error_out "Could not setup openshift storage" ${ERROR_CODE_STORAGE_FAILURE}
 
-  vgdisplay vg-docker &>/dev/null
-  vgd=$?
-
-  vgdisplay vg-openshift &>/dev/null
-  vgo=$?
-
-  if [ ${vgd} -eq 0 ] && [ ${vgo} -eq 0 ]; then
-    echo "Storage already configured!"
-    return 0
-  fi
-
-  # Create partition table for the disk:
-  # /dev/vdb1 - 20GB for docker
-  # /dev/vdb2 - 2GB for openshift (/var/lib/openshift)
-  cat << EOF > /tmp/ose_vdb_layout.txt
-# partition table of /dev/vdb
-unit: sectors
-
-/dev/vdb1 : start=     2048, size= 41943040, Id=8e
-/dev/vdb2 : start= 41945088, size=  4194304, Id=8e
-/dev/vdb3 : start=        0, size=        0, Id= 0
-/dev/vdb4 : start=        0, size=        0, Id= 0
-EOF
-
-  sfdisk /dev/vdb < /tmp/ose_vdb_layout.txt
-  rm -f /tmp/ose_vdb_layout.txt
-
-  pvcreate /dev/vdb1
-  vgcreate vg-docker /dev/vdb1
-
-  cat << EOF > /etc/sysconfig/docker-storage-setup
-VG=vg-docker
-SETUP_LVM_THIN_POOL=yes
-EOF
-
-  # Let docker setup the storage based on the above config file
-  docker-storage-setup
-
-  # Create LVM and set up /var/lib/openshift
-  pvcreate /dev/vdb2
-  vgcreate vg-openshift /dev/vdb2
-  lvcreate -l 100%FREE -n lv-ose vg-openshift
-
-  mkfs.xfs -q -f /dev/vg-openshift/lv-ose
-
-  mkdir -p /var/lib/openshift
-  echo "/dev/vg-openshift/lv-ose        /var/lib/openshift              xfs defaults 0 0" >> /etc/fstab
-
-  mount -a
+  # Always run the docker storage setup last as it will use what's left of the disk
+  setup_docker_storage ${OPENSHIFT_DISK_PART_DOCKER}
+  [ $? -eq 0 ] || error_out "Could not setup docker storage" ${ERROR_CODE_STORAGE_FAILURE}
 
   return 0
 }
@@ -368,6 +321,9 @@ OPENSHIFT_USERS=${CONF_OPENSHIFT_USERS:=$openshift_users}
 OPENSHIFT_BASE_DOMAIN=${CONF_OPENSHIFT_BASE_DOMAIN:=$openshift_base_domain}
 OPENSHIFT_MASTER_CONFIG=$openshift_master_config
 OPENSHIFT_ZONES=$openshift_zones
+OPENSHIFT_DISK_PATH_DOCKER=${CONF_DISK_PATH_DOCKER:=$default_disk_path_docker}
+OPENSHIFT_DISK_PATH_OSE=${CONF_DISK_PATH_OSE:=$default_disk_path_ose}
+OPENSHIFT_PART_SIZE_OSE=${CONF_PART_SIZE_OSE:=$default_part_size_ose}
 
 # Begin installation phases
 process_actions ${ACTIONS?"Missing argument -a or --action"}

--- a/provisioning/osc-provision
+++ b/provisioning/osc-provision
@@ -181,7 +181,7 @@ provision_masters() {
   --key ${key} \
   --image-name ${IMAGE_NAME} \
   --security-groups ${SECURITY_GROUP_MASTER} \
-  --add-volume 25 \
+  --add-volume ${VOLUME_SIZE} \
   --n \
   --debug"
   $command || error_out "Master Provision failed. See log at ${LOGFILE}." ${ERROR_CODE_PROVISION_FAILURE}
@@ -195,7 +195,7 @@ provision_nodes() {
   --image-name ${IMAGE_NAME} \
   --security-groups ${SECURITY_GROUP_NODE} \
   --num-instances $num_of_nodes \
-  --add-volume 25 \
+  --add-volume ${VOLUME_SIZE} \
   --n \
   --debug"
   $command || error_out "Node Provision failed. See log at ${LOGFILE}." ${ERROR_CODE_PROVISION_FAILURE}
@@ -248,6 +248,7 @@ LOGFILE=${CONF_LOGFILE:-$logfile}
 OPENSHIFT_BASE_DOMAIN=${CONF_OPENSHIFT_BASE_DOMAIN:-$openshift_base_domain}
 OPENSHIFT_CLOUDAPPS_SUBDOMAIN=${CONF_OPENSHIFT_CLOUDAPPS_SUBDOMAIN:-$cloudapp_subdomain}
 PROVISION_COMPONENTS=${CONF_PROVISION_COMPONENTS:-$provision_components}
+VOLUME_SIZE=${CONF_VOLUME_SIZE:-$default_volume_size}
 
 case $action in
   "provision")

--- a/provisioning/osc-provision
+++ b/provisioning/osc-provision
@@ -248,7 +248,7 @@ LOGFILE=${CONF_LOGFILE:-$logfile}
 OPENSHIFT_BASE_DOMAIN=${CONF_OPENSHIFT_BASE_DOMAIN:-$openshift_base_domain}
 OPENSHIFT_CLOUDAPPS_SUBDOMAIN=${CONF_OPENSHIFT_CLOUDAPPS_SUBDOMAIN:-$cloudapp_subdomain}
 PROVISION_COMPONENTS=${CONF_PROVISION_COMPONENTS:-$provision_components}
-VOLUME_SIZE=${CONF_VOLUME_SIZE:-$default_volume_size}
+VOLUME_SIZE=${CONF_VOLUME_SIZE:-$storage_volume_size}
 
 case $action in
   "provision")


### PR DESCRIPTION
@etsauer change for the dynamic disk partitioning. Issue #13.

Please note the following architecture:
- Using the following default values (which can be overridden through conf files), the default disk device to use for the extra storage is /dev/vdb. The OSE partition is defaulted to be 2GB and the Docker VG will consume whatever is left of the disk. With these default values, that means that the docker VG gets approx 8GB. 

```
storage_disk_volume="/dev/vdb"
storage_volume_size="10"
storage_size_ose="2"
```

Note: Using a configuration file, the OSE and Docker partitions can reside on different disk devices - e.g.: /dev/vdb for one and /dev/vdc for the other.
