### PR TITLE
Mounting ssh dir to /mnt/ssh and cp-ing to /root/.ssh so that user pe…

### DIFF
--- a/provisioning/openstack-docker-client/bin/start.sh
+++ b/provisioning/openstack-docker-client/bin/start.sh
@@ -3,14 +3,22 @@
 # start.sh - Helper script that is executed when the Docker container is started up to arrange files in the proper locations
 
 SSH_DIR=/root/.ssh
-INPUT_SSH_DIR=/root/ssh
+INPUT_SSH_DIR=/mnt/.ssh
 CONFIG_DIR=/root/.openstack
+
+# Copy mounted .ssh directory to ~/.ssh
+if [ -d $INPUT_SSH_DIR ]; then
+
+	mkdir -p $SSH_DIR
+	cp $INPUT_SSH_DIR/* $SSH_DIR/
+
+fi
 
 # Attempt to source files for OpenStack
 if [ -d $CONFIG_DIR ]; then
 
 	FILES=$CONFIG_DIR/*.sh
-	
+
 	for file in $FILES
 	do
 		source $file

--- a/provisioning/openstack-docker-client/run.sh
+++ b/provisioning/openstack-docker-client/run.sh
@@ -65,20 +65,20 @@ fi
 
 # Check if Image has been build previously
 if [ ! -z ${REPOSITORY} ]; then
-	
+
 	if [ ! -d ${REPOSITORY} ]; then
 		echo "Error: Could not locate specified repository directory"
 		exit 1
 	fi
-	
+
 	REPOSITORY_VOLUME="-v ${REPOSITORY}:/root/repository:z"
-	
+
 	echo
-	echo "Git Repository containing scripts are found and mounted in the '/root/repository' folder"	
+	echo "Git Repository containing scripts are found and mounted in the '/root/repository' folder"
 fi
 
 if [ -d $SSH_DIR ]; then
-	SSH_VOLUME="-v ${SSH_DIR}:/root/.ssh:z"
+	SSH_VOLUME="-v ${SSH_DIR}:/mnt/.ssh:z"
 else
 	echo "Warning: SSH Directory not found"
 fi


### PR DESCRIPTION
…rmissions on the host don't carry over and break SSH
#### What does this PR do?

We made a change to the openstack-docker-client recently to make it so we didn't see an ssh directory twice in HOMEDIR. The first solution was to mount the hosts `~/.ssh` dir directly to `/root/.ssh` inside the container. This created a bug as the container ssh dir was owned by the uid of the user on the host, rather than `root`. We fix this by mounting the host's `~/.ssh` dir to `/mnt/.ssh` and then doing a copy from there to `/root/.ssh`.
#### How should this be manually tested?

Checkout this branch, then run:

```
./provisioning/openstack-docker-client/run.sh --ssh=/home/esauer/.ssh --repository=/home/esauer/workspace/redhat-consulting/rhc-ose
# Look in the ssh dir and make sure your keys are there
[root@ec484734d463 ~]# ls -a .ssh
... should see keys here
# Now test that you can successfully ssh to a server using your keys
[root@ec484734d463 ~]# ssh root@master.p1.rhc-ose.labs.redhat.com
Last login: Tue Oct 13 14:23:42 2015 from 10.10.48.170
[root@master ~]# exit
logout
Connection to master.p1.rhc-ose.labs.redhat.com closed.
[root@ec484734d463 ~]# 
```
#### Is there a relevant Issue open for this?

https://github.com/rhtconsulting/rhc-ose/issues/24
#### Who would you like to review this?

/cc @sabre1041 
