### PR TITLE
Allow root login for base image

### DIFF
--- a/provisioning/kvm/ks.cfg
+++ b/provisioning/kvm/ks.cfg
@@ -74,6 +74,9 @@ yum install -y --enablerepo=epel cloud-init
 # Disable the zeroconf route
 echo "NOZEROCONF=yes" >> /etc/sysconfig/network
 
+# Enable direct root login
+sed -i 's/disable_root: 1/disable_root: 0/' /etc/cloud/cloud.cfg
+
 # Remove "unecessary" packages
 yum remove -y NetworkManager*
 yum remove -y firewalld


### PR DESCRIPTION
#### What does this PR do?

With this change, the provisioning can be done by any user as the users SSH key will be added to the root login and hence allow direct logins.
#### How should this be manually tested?
1. Use the provisioning/kvm/create_base_img.sh to generate a new base image
2. Use the provisioning/openstack/create_base_image to tailor it to fit an OSE deployment
3. Use the provisioning/osc-provision to deploy a new environment with the image created by 1 & 2 above. Validate that the deployment is successful. 
   NOTE: step 3 above should be performed by a user whose SSH pub key is not part of the ose3eval/ose3_public_keys file. 
#### Is there a relevant Issue open for this?

Yes, see #34 
#### Who would you like to review this?

/cc @etsauer 
