### PR TITLE
Updated usage to account for correct config parameter name

### DIFF
--- a/provisioning/osc-provision
+++ b/provisioning/osc-provision
@@ -36,7 +36,7 @@ usage() {
 
   Options:
   --num-nodes=<integer>         : Number of Nodes to provision
-  --config-file=<path>          : Path to a config file for defining the environment
+  --config=<path>               : Path to a config file for defining the environment
   --no-install                  : Provision instances and sync keys, but do not run the OpenShift installer
   --key=<key name>              : SSH Key used to authenticate to Cloud API
   --delete=<Environment ID>     : Delete specified environment


### PR DESCRIPTION
#### What does this PR do?

Updates the usage portion of the osc-provision script to account for the correct parameter name
#### How should this be manually tested?

Verify correct parameter name
#### Is there a relevant Issue open for this?

None
#### Who would you like to review this?

/cc @etsauer 
