### PR TITLE
Updates to cicd installation to account for changes in base image

### DIFF
--- a/provisioning/cicd-install
+++ b/provisioning/cicd-install
@@ -72,10 +72,15 @@ function check_prereqs() {
 function install_prereqs() {
 	
 	# EPEL and software packages	
-	yum install -y install http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm wget unzip git vim jq &>/dev/null || error_out "Failed to install prerequisite software" 2
+	yum install -y install http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm wget unzip git vim firewalld &>/dev/null || error_out "Failed to install prerequisite software" 2
 
 	# JQ must be installed only after EPEL installed
-	yum install -y install jq &>/dev/null || error_out "Failed to install prerequisite software" 2
+	yum --enablerepo=epel install -y jq &>/dev/null || error_out "Failed to install prerequisite software" 2
+	
+	# Start and enable firewalld
+	systemctl enable firewalld
+	systemctl start firewalld
+
 }
 
 #


### PR DESCRIPTION
#### What does this PR do?

Updates the CICD installation/provisioning to account for changes to the base OS1 image
#### How should this be manually tested?

Pull down changes from this PR

Create a new configuration file 

```
CONF_ENV_ID= # Default: random 8 character string
CONF_IMAGE_NAME=ose3-base # Default: ose3-base
CONF_SECURITY_GROUP_MASTER=ose3-master # Default: ose3-master
CONF_SECURITY_GROUP_NODE=ose3-node # Default: ose3-node
CONF_LOGFILE=~/openstack_provision.log # Default: ~/openstack_provision.log
CONF_STORAGE_DISK_VOLUME=/dev/vdb # The disk path (within an instance) for the "extra" storage volume used by OSE/Docker (see below) # Default: /dev/vdb
CONF_VOLUME_SIZE=25 # Allocate a 25 GB volume for a shared OpenShift / Docker disk (see "CONF_STORAGE_SIZE_OSE" below - OSE uses the first X GB and leaves the rest for Docker storage) # Default: 10 GB
CONF_STORAGE_SIZE_OSE=4 # Allocate 4 GB for the OpenShift partition (e.g.: /var/lib/openshift) # Default: 2 GB
## OpenShift Configs
CONF_OPENSHIFT_BASE_DOMAIN=openshift.example.com # Default: ose.example.com
CONF_OPENSHIFT_CLOUDAPPS_SUBDOMAIN=*.cloudapps # Default: *.apps
CONF_PROVISION_COMPONENTS=cicd # Comman separated list. Supported values are: openshift,cicd. Default: openshift
```

Run the provisioning script

```
./osc-provision --config=<path_to_config_file> --key=<key_name> 
```

Please adjust the above command to account for specific configurations if necessary
#### Is there a relevant Issue open for this?

None
#### Who would you like to review this?

/cc @etsauer 
