### PR TITLE
Error checking when docker socket is unavailable

### DIFF
--- a/provisioning/openstack-docker-client/run.sh
+++ b/provisioning/openstack-docker-client/run.sh
@@ -67,6 +67,11 @@ fi
 
 OPENSTACK_IMAGE=$(docker images | awk '{ print $1 }' | grep ${OPENSTACK_CLIENT_IMAGE})
 
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to determine installed docker images. Please verify connectivity to Docker socket"
+    exit 1
+fi
+
 # Check if Image has been build previously
 if [ -z $OPENSTACK_IMAGE ]; then
 	echo "Building Docker Image ${OPENSTACK_CLIENT_IMAGE}...."


### PR DESCRIPTION
#### What does this PR do?

Adds an error check to the run script to stop launching the docker container is connectivity cannot be made with Docker
#### How should this be manually tested?

Stop the Docker service on your machine. Attempt the execute the `run.sh` script. An error should be thrown stating that connectivity to docker was unsuccessful and the script should execute with no further action
#### Is there a relevant Issue open for this?

No
#### Who would you like to review this?

/cc @jradtke-rh  @JaredBurck
