### PR TITLE
Updating registry creation to account for change in oc output formatt…

### DIFF
--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -225,7 +225,7 @@ do_create_registry() {
   CA=/etc/openshift/master
 
   # First, a bit of cleanup so we can re-run and update things
-  for resource in service deploymentConfig pod; do
+  for resource in service deploymentConfig pod route serviceaccount secret; do
     resource_names=$(oc get $resource | awk '/registry/ {print $1}')
     for name in ${resource_names/'\n'/ }; do
       oc delete $resource $name
@@ -251,7 +251,7 @@ do_create_registry() {
 
   service_name=$(echo "${created_resources}" | awk -F'/' '/services/ {print $2}')
   dc_name=$(echo "${created_resources}" | awk -F'/' '/deploymentconfigs/ {print $2}')
-  service_ip=$(oc get service $service_name | awk '/registry/ {print $4}')
+  service_ip=$(oc get service $service_name | awk '/registry/ {print $2}')
 
   # Secure the Registry
   oadm ca create-server-cert --signer-cert=$CA/ca.crt \
@@ -274,8 +274,8 @@ do_create_registry() {
     for dir in $certs_dirs; do
       $SSH_CMD $node "mkdir -p $dir"
       $SCP_CMD $CA/ca.crt $node:$dir
-      $SSH_CMD $node "systemctl daemon-reload && systemctl restart docker"
     done
+    $SSH_CMD $node "systemctl daemon-reload && systemctl restart docker && systemctl restart openshift-node"
   done
 
   # Create Route for External Access


### PR DESCRIPTION
…ing in OSE 3.0.2.0
#### What does this PR do?

The release of OSE 3.0.2.0 created a bug in the script, as it tries to run an `oc get service` to grab a service IP. The release changed the output format, which broke the script. This PR fixes that bug.
#### How should this be manually tested?

```
./rhc-ose/provisioning/osc-provision --num-nodes=2 --key=<keyname>
```

Now, create a project and run a build to see that internal push to registry works.

```
oadm new-project nodejs-test
oc new-app --template=nodejs-example -n nodejs-test
oc start-build nodejs-example -n nodejs-test
oc build-log <build-name> -n nodejs-test
```

Make sure build succeeds.

Now, make sure you can curl the registry using the external route created for the registry.

```
oc get routes
NAME       HOST/PORT                                  PATH      SERVICE           LABELS                    TLS TERMINATION
registry   <route hostname>             docker-registry   docker-registry=default   passthrough

curl -v --cacert /etc/docker/certs.d/<route hostname>/ca.crt https://<route-hostname>/v1/_ping
# expected result is a 404
```
#### Is there a relevant Issue open for this?

n/a
#### Who would you like to review this?

/cc @sabre1041 @oybed 
