### PR TITLE
Fixed bug in dns config script to handle empty -p option + added extr…

### DIFF
--- a/provisioning/osc-dns-config
+++ b/provisioning/osc-dns-config
@@ -148,8 +148,12 @@ function setIPtables()
   [ \$(grep -c '"$tcp"' /etc/sysconfig/iptables) == 0 ] && \
   sed -i \"/-A INPUT -j REJECT/i $tcp\" /etc/sysconfig/iptables
 
-  systemctl stop firewalld
+  # Stop and disable firewalld if it's currently running and/or enabled
+  systemctl status firewalld &>/dev/null
+  [ \$? -eq 0 ] && systemctl stop firewalld
+  [ -n "`systemctl status firewalld | grep '.service; enabled'`" ] && \
   systemctl disable firewalld
+
   sleep 1
   systemctl restart iptables
 "
@@ -443,7 +447,7 @@ then
   exit 1
 fi
 
-[ -z "${WILDCARD_PREFIX}" ] && WILDCARD_PREFIX=DEFAULT_WILDCARD_PREFIX
+[ -z "${WILDCARD_PREFIX}" ] && WILDCARD_PREFIX="${DEFAULT_WILDCARD_PREFIX}.${BASE_DOMAIN}"
 
 
 installDNSserver ${dh_private_ip}

--- a/provisioning/osc-dns-config
+++ b/provisioning/osc-dns-config
@@ -151,7 +151,7 @@ function setIPtables()
   # Stop and disable firewalld if it's currently running and/or enabled
   systemctl status firewalld &>/dev/null
   [ \$? -eq 0 ] && systemctl stop firewalld
-  [ -n "`systemctl status firewalld | grep '.service; enabled'`" ] && \
+  [ -n \"\`systemctl status firewalld | grep '.service; enabled'\`\" ] && \
   systemctl disable firewalld
 
   sleep 1

--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -196,7 +196,7 @@ do_post(){
 
   oadm ca create-server-cert --signer-cert=$CA/ca.crt \
   --signer-key=$CA/ca.key --signer-serial=$CA/ca.serial.txt \
-  --hostnames="*.${OPENSHIFT_BASE_DOMAIN}" \
+  --hostnames="*.${OPENSHIFT_CLOUDAPPS_SUBDOMAIN}.${OPENSHIFT_BASE_DOMAIN}" \
   --cert=$CA/cloudapps.crt --key=$CA/cloudapps.key
 
 


### PR DESCRIPTION
…a checking for firewalld
#### What does this PR do?
1. Fixed a bug when the -p command line argument is empty
2. Added some extra checking for firewalld to avoid printing errors when firewalld isn't installed
#### How should this be manually tested?

Run the following command:

```
osc-dns-config -m="master_priv_ip|master_pub_ip" -n="node1_priv_ip|node1_pub_ip,node2_priv_ip|node2_pub_ip,node3_priv_ip|node3_pub_ip" -b="ose.example.com" -d="dns_server_priv_ip|dns_server_pub_ip" -w="wildcard_priv_ip|wildcard_pub_ip" -p=""
```

_NOTE_ replace the priv_ip and pub_ip entries above appropriate IPs for the env used for testing. 

Check that the DNS server's wild card entries are populated with the default "*.apps.ose.example.com"

Also, run the above command on a system that has firewalld installed, enabled and running. Check that the command actually stops and disables firewalld (i.e.: systemctl status firewalld). Then, run the command again and observe that there are no errors displayed.
#### Is there a relevant Issue open for this?

N/A
#### Who would you like to review this?

/cc @etsauer 
