### PR TITLE
updated if check for grep return code to be greater than 1

### DIFF
--- a/provisioning/openstack-docker-client/run.sh
+++ b/provisioning/openstack-docker-client/run.sh
@@ -67,7 +67,7 @@ fi
 
 OPENSTACK_IMAGE=$(docker images | awk '{ print $1 }' | grep ${OPENSTACK_CLIENT_IMAGE})
 
-if [ $? -ne 0 ]; then
+if [ $? -gt 1 ]; then
     echo "Error: Failed to determine installed docker images. Please verify connectivity to Docker socket"
     exit 1
 fi

--- a/provisioning/openstack-docker-client/run.sh
+++ b/provisioning/openstack-docker-client/run.sh
@@ -65,11 +65,18 @@ if [ ! -d ${OPENSTACK_CONFIG_DIR} ]; then
 	exit 1
 fi
 
+DOCKER_IMAGES=$(docker images)
+
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to determine installed docker images. Please verify connectivity to Docker socket"
+    exit 1
+fi
+
 OPENSTACK_IMAGE=$(docker images | awk '{ print $1 }' | grep ${OPENSTACK_CLIENT_IMAGE})
 
 if [ $? -gt 1 ]; then
-    echo "Error: Failed to determine installed docker images. Please verify connectivity to Docker socket"
-    exit 1
+  echo "Error: Failed to find installed ${OPENSTACK_CLIENT_IMAGE} image. Please verify with docker images."
+  exit 1
 fi
 
 # Check if Image has been build previously


### PR DESCRIPTION
#### What does this PR do?

Brief explanation of the code or documentation change you've made:

Updated if return code test from -ne 0 to -gt 1

The grep utility exits with one of the following values:
-     0     One or more lines were selected.
-    1     No lines were selected.
-    >1    An error occurred.

When no docker image was found or had been previously built, the run.sh script would return 1 and error out with the message: "Error: Failed to determine installed docker images. Please verify connectivity to Docker socket".
#### How should this be manually tested?

Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)

Steps to recreate:

``` bash
docker rmi {openstack-docker-client id}
./run.sh --repository=/path/to/repo
```

Same steps as above to verify this works after update.
#### Is there a relevant Issue open for this?

Provide a link to any open issues that describe the problem you are solving.

No, though worked with Andy for this solution.
#### Who would you like to review this?

/cc @sabre1041 @etsauer 
