### PR TITLE
Fixing name argument

### DIFF
--- a/provisioning/openstack-docker-client/run.sh
+++ b/provisioning/openstack-docker-client/run.sh
@@ -38,7 +38,7 @@ do
 	  -k|--keep)
       REMOVE_CONTAINER_ON_EXIT=""
       shift;;
-  	-n|--name)
+  	-n=*|--name=*)
       OPENSTACK_CLIENT_IMAGE="${i#*=}"
       shift;;
     -s=*|--ssh=*)


### PR DESCRIPTION
#### What does this PR do?

The --name=<name> argument doesn't work. This PR fixes it.
#### How should this be manually tested?

```
./provisioning/openstack-docker-client/run.sh --name=named-container-bugfix --repository=/home/esauer/workspace/redhat-consulting/
```
#### Is there a relevant Issue open for this?

n/a
#### Who would you like to review this?

/cc @sabre1041 
