### PR TITLE
Docker client run fix

### DIFF
--- a/provisioning/openstack-docker-client/run.sh
+++ b/provisioning/openstack-docker-client/run.sh
@@ -67,7 +67,7 @@ fi
 
 OPENSTACK_IMAGE=$(docker images | awk '{ print $1 }' | grep ${OPENSTACK_CLIENT_IMAGE})
 
-if [ $? -ne 0 ]; then
+if [ $? -gt 1 ]; then
     echo "Error: Failed to determine installed docker images. Please verify connectivity to Docker socket"
     exit 1
 fi

--- a/provisioning/openstack-docker-client/run.sh
+++ b/provisioning/openstack-docker-client/run.sh
@@ -68,11 +68,11 @@ fi
 DOCKER_IMAGES=$(docker images)
 
 if [ $? -ne 0 ]; then
-    echo "Error: Failed to determine installed docker images. Please verify connectivity to Docker socket"
+    echo "Error: Failed to determine installed docker images. Please verify connectivity to Docker socket."
     exit 1
 fi
 
-OPENSTACK_IMAGE=$(docker images | awk '{ print $1 }' | grep ${OPENSTACK_CLIENT_IMAGE})
+OPENSTACK_IMAGE=$(${DOCKER_IMAGES} | awk '{ print $1 }' | grep ${OPENSTACK_CLIENT_IMAGE})
 
 if [ $? -gt 1 ]; then
   echo "Error: Failed to find installed ${OPENSTACK_CLIENT_IMAGE} image. Please verify with docker images."

--- a/provisioning/openstack-docker-client/run.sh
+++ b/provisioning/openstack-docker-client/run.sh
@@ -65,11 +65,18 @@ if [ ! -d ${OPENSTACK_CONFIG_DIR} ]; then
 	exit 1
 fi
 
+DOCKER_IMAGES=$(docker images)
+
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to determine installed docker images. Please verify connectivity to Docker socket"
+    exit 1
+fi
+
 OPENSTACK_IMAGE=$(docker images | awk '{ print $1 }' | grep ${OPENSTACK_CLIENT_IMAGE})
 
 if [ $? -gt 1 ]; then
-    echo "Error: Failed to determine installed docker images. Please verify connectivity to Docker socket"
-    exit 1
+  echo "Error: Failed to find installed ${OPENSTACK_CLIENT_IMAGE} image. Please verify with docker images."
+  exit 1
 fi
 
 # Check if Image has been build previously

--- a/provisioning/openstack-docker-client/run.sh
+++ b/provisioning/openstack-docker-client/run.sh
@@ -75,7 +75,7 @@ fi
 OPENSTACK_IMAGE=$(${DOCKER_IMAGES} | awk '{ print $1 }' | grep ${OPENSTACK_CLIENT_IMAGE})
 
 if [ $? -gt 1 ]; then
-  echo "Error: Failed to find installed ${OPENSTACK_CLIENT_IMAGE} image. Please verify with docker images."
+  echo "Error: Failed to parse the Docker images to find ${OPENSTACK_CLIENT_IMAGE} image."
   exit 1
 fi
 


### PR DESCRIPTION
#### What does this PR do?

Updated run.sh script to split out check for docker service running and if docker image found.

When no docker image was found or had been previously built, the run.sh script would return 1 and error out with the message: "Error: Failed to determine installed docker images.  Please verify connectivity to Docker socket".
#### How should this be manually tested?

Steps to recreate:

``` bash
docker rmi {openstack-docker-client id}
./run.sh --repository=/path/to/repo
```

Same steps as above to verify this works after update.
#### Is there a relevant Issue open for this?

Previous PR #50 
https://github.com/rhtconsulting/rhc-ose/pull/50
#### Who would you like to review this?

/cc @sabre1041 
