### PR TITLE
Adding support for defining a custom auth provider

### DIFF
--- a/provisioning/lib/constants
+++ b/provisioning/lib/constants
@@ -9,6 +9,8 @@ openshift_base_domain="ose.example.com"
 openshift_master_config='/etc/openshift/master/master-config.yaml'
 openshift_users="joe:redhat alice:redhat"
 openshift_zones=("east" "west")
+openshift_identity_provider=htpasswd_auth
+openshift_identity_provider_json="{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '\/etc\/openshift\/openshift-passwd'}"
 master_is_node=true
 platform="openstack" # Only one we support
 image_name="ose3-base"
@@ -22,4 +24,3 @@ provision_components="openshift"
 storage_disk_volume="/dev/vdb"
 storage_volume_size="10"
 storage_size_ose="2"
-

--- a/provisioning/lib/helpers
+++ b/provisioning/lib/helpers
@@ -47,15 +47,30 @@ get_public_ips() {
 
 process_configfile() {
   file=$1
+  unset CONF_ENVIRONMENT
 
   # Filter Configs to make sure only valid key pair values are acted upton
   configs=$(egrep '^[^ ]*=[^;&]*' $file | grep -v '^#' | sed 's/#.*//g')
 
   # export all variables to the environment
   for var in ${configs//'\n'/ }; do
-    CONF_ENVIRONMENT="${CONF_ENVIRONMENT}export $var;"$'\n'
+    CONF_ENVIRONMENT="${CONF_ENVIRONMENT}export $var"$'\n'
     export $var
   done
+
+  # handle special cases
+
+  # Setup user-defined auth Provider
+  if [ -f ${CONF_OPENSHIFT_IDENTITY_PROVIDER} ]; then
+    # User is providing a file containing custom auth provider, load it
+    CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON=$(cat ${CONF_OPENSHIFT_IDENTITY_PROVIDER} | sed -e 's/[\/&]/\\&/g')
+  else
+    # Use the matching provider in templates directory
+    CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON=$(cat ${SCRIPT_BASE_DIR}/templates/${CONF_OPENSHIFT_IDENTITY_PROVIDER} | sed -e 's/[\/&]/\\&/g')
+  fi
+
+  CONF_ENVIRONMENT="${CONF_ENVIRONMENT}export CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON=\"${CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON}\""$'\n'
+  export CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON="${CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON}"
 }
 
 ## Template Format ##
@@ -104,7 +119,7 @@ function partition_disk() {
 
   # If we do indeed have some partitions already configured, check to see that we're less than
   # 4 primary - can only handle up to 4 primary partitions for now...
-  if [ ${part_start} -ne 0 ]; then 
+  if [ ${part_start} -ne 0 ]; then
     end_idx=`parted -m ${root_disk} print | tail -n 1 | awk -F: '{ print $1 }'`
     [ ${end_idx} -gt 4 ] && return 1
   fi
@@ -117,7 +132,7 @@ function partition_disk() {
   fi
 
   parted ${root_disk} --script -- mkpart primary "${part_start}MB" "${part_end}MB"
-  [ $? -ne 0 ] && return 1 
+  [ $? -ne 0 ] && return 1
 
   partprobe
 
@@ -188,4 +203,3 @@ setup_openshift_storage() {
 
   return 0
 }
-

--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -84,8 +84,11 @@ EOF
   # Prepare the apps sub domain:
   CLOUDAPPS_SUBDOMAIN="${OPENSHIFT_CLOUDAPPS_SUBDOMAIN}.${OPENSHIFT_BASE_DOMAIN}"
 
-  echo "process_template ${SCRIPT_BASE_DIR}/templates/ansible-hosts MASTER_HOSTNAME NODESTRING CLOUDAPPS_SUBDOMAIN"
-  ansible_hosts_file="$(process_template ${SCRIPT_BASE_DIR}/templates/ansible-hosts MASTER_HOSTNAME NODESTRING CLOUDAPPS_SUBDOMAIN)"
+  if [ -z "${OPENSHIFT_IDENTITY_PROVIDER_JSON}" ]; then
+    error_out "OPENSHIFT_IDENTITY_PROVIDER_JSON cannot be empty: ${OPENSHIFT_IDENTITY_PROVIDER_JSON}"
+  fi
+  echo "process_template ${SCRIPT_BASE_DIR}/templates/ansible-hosts MASTER_HOSTNAME NODESTRING OPENSHIFT_IDENTITY_PROVIDER_JSON"
+  ansible_hosts_file="$(process_template ${SCRIPT_BASE_DIR}/templates/ansible-hosts MASTER_HOSTNAME NODESTRING OPENSHIFT_IDENTITY_PROVIDER_JSON)"
 
   cd
   rm -rf ~/openshift-ansible
@@ -327,6 +330,7 @@ OPENSHIFT_MASTER_CONFIG=$openshift_master_config
 OPENSHIFT_ZONES=$openshift_zones
 OPENSHIFT_STORAGE_DISK_VOLUME=${CONF_STORAGE_DISK_VOLUME:=$storage_disk_volume}
 OPENSHIFT_STORAGE_SIZE_OSE=${CONF_STORAGE_SIZE_OSE:=$storage_size_ose}
+OPENSHIFT_IDENTITY_PROVIDER_JSON="${CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON:=$openshift_identity_provider_json}"
 
 # Begin installation phases
 process_actions ${ACTIONS?"Missing argument -a or --action"}

--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -87,8 +87,8 @@ EOF
   if [ -z "${OPENSHIFT_IDENTITY_PROVIDER_JSON}" ]; then
     error_out "OPENSHIFT_IDENTITY_PROVIDER_JSON cannot be empty: ${OPENSHIFT_IDENTITY_PROVIDER_JSON}"
   fi
-  echo "process_template ${SCRIPT_BASE_DIR}/templates/ansible-hosts MASTER_HOSTNAME NODESTRING OPENSHIFT_IDENTITY_PROVIDER_JSON"
-  ansible_hosts_file="$(process_template ${SCRIPT_BASE_DIR}/templates/ansible-hosts MASTER_HOSTNAME NODESTRING OPENSHIFT_IDENTITY_PROVIDER_JSON)"
+  echo "process_template ${SCRIPT_BASE_DIR}/templates/ansible-hosts MASTER_HOSTNAME NODESTRING CLOUDAPPS_SUBDOMAIN OPENSHIFT_IDENTITY_PROVIDER_JSON"
+  ansible_hosts_file="$(process_template ${SCRIPT_BASE_DIR}/templates/ansible-hosts MASTER_HOSTNAME NODESTRING CLOUDAPPS_SUBDOMAIN OPENSHIFT_IDENTITY_PROVIDER_JSON)"
 
   cd
   rm -rf ~/openshift-ansible

--- a/provisioning/osc-provision
+++ b/provisioning/osc-provision
@@ -46,6 +46,7 @@ usage() {
 
 do_provision() {
 
+  ENV_ID=${ENV_ID}-$(random_string 8)
   FINAL_OUTPUT=""
 
   for component in ${PROVISION_COMPONENTS//,/ }; do
@@ -137,6 +138,15 @@ provision_openshift() {
     node_ips="${master_ip}"$'\n'"${node_ips}"
   fi
 
+  # Sync user file to instances
+  if [ -n "${OPENSHIFT_MASTER_FILES}" ]; then
+    sync_files "${OPENSHIFT_MASTER_FILES}" "${master_public}"
+  fi
+
+  if [ -n "${OPENSHIFT_NODE_FILES}"]; then
+    sync_files "${OPENSHIFT_NODE_FILES}" "${node_publics}"
+  fi
+
   if $no_install; then
     echo "Skipping Installation Step. You'll need to do this manually."
   else
@@ -201,6 +211,20 @@ provision_nodes() {
   $command || error_out "Node Provision failed. See log at ${LOGFILE}." ${ERROR_CODE_PROVISION_FAILURE}
 }
 
+sync_files() {
+  # Sync files from variable with format "file1:dest1 file2:dest2"
+  files=$1
+  nodes=$2
+
+  for node in $nodes; do
+    for file in $files; do
+      source=${file%:*}
+      dest=${file#*:}
+      ${SCP_CMD} ${source} root@${node}:${dest}
+    done
+  done
+}
+
 source ${SCRIPT_BASE_DIR}/lib/error_codes
 
 # Process input
@@ -239,7 +263,7 @@ done
 
 # Set up environment based on default values and User input
 
-ENV_ID=${CONF_ENV_ID:-${env_id}-$(random_string 8)}
+ENV_ID=${CONF_ENV_ID:-${env_id}}
 IMAGE_NAME=${CONF_IMAGE_NAME:-$image_name}
 SECURITY_GROUP_MASTER=${CONF_SECURITY_GROUP_MASTER:-$security_group_master}
 SECURITY_GROUP_NODE=${CONF_SECURITY_GROUP_NODE:-$security_group_node}
@@ -248,6 +272,9 @@ LOGFILE=${CONF_LOGFILE:-$logfile}
 OPENSHIFT_BASE_DOMAIN=${CONF_OPENSHIFT_BASE_DOMAIN:-$openshift_base_domain}
 PROVISION_COMPONENTS=${CONF_PROVISION_COMPONENTS:-$provision_components}
 VOLUME_SIZE=${CONF_VOLUME_SIZE:-$storage_volume_size}
+OPENSHIFT_MASTER_FILES="${CONF_OPENSHIFT_MASTER_FILES}"
+OPENSHIFT_NODE_FILES="${CONF_OPENSHIFT_NODE_FILES}"
+
 
 case $action in
   "provision")

--- a/provisioning/osc-provision
+++ b/provisioning/osc-provision
@@ -216,6 +216,7 @@ sync_files() {
   files=$1
   nodes=$2
 
+  # TODO: it may become necessary to support setting ownership, permissions, and SELinux context
   for node in $nodes; do
     for file in $files; do
       source=${file%:*}

--- a/provisioning/sample.cfg
+++ b/provisioning/sample.cfg
@@ -9,5 +9,5 @@ CONF_OPENSHIFT_BASE_DOMAIN=openshift.example.com # Default: ose.example.com
 CONF_OPENSHIFT_CLOUDAPPS_SUBDOMAIN=cloudapps # Default: apps
 CONF_PROVISION_COMPONENTS=openshift # Comman separated list. Supported values are: openshift,cicd. Default: openshift
 CONF_OPENSHIFT_IDENTITY_PROVIDER=htpasswd_auth # Default: htpasswd_auth
-#CONF_OPENSHIFT_MASTER_FILES=
-#CONF_OPENSHIFT_NODE_FILES=
+#CONF_OPENSHIFT_MASTER_FILES= # Example value: /path/to/source:/path/to/dest /path/to/source2:/path/to/dest2; Default is null
+#CONF_OPENSHIFT_NODE_FILES= # Example value: /path/to/source:/path/to/dest /path/to/source2:/path/to/dest2; Default is null

--- a/provisioning/sample.cfg
+++ b/provisioning/sample.cfg
@@ -8,3 +8,6 @@ CONF_SECURITY_GROUP_NODE=ose3-node # Default: ose3-node
 CONF_OPENSHIFT_BASE_DOMAIN=openshift.example.com # Default: ose.example.com
 CONF_OPENSHIFT_CLOUDAPPS_SUBDOMAIN=cloudapps # Default: apps
 CONF_PROVISION_COMPONENTS=openshift # Comman separated list. Supported values are: openshift,cicd. Default: openshift
+CONF_OPENSHIFT_IDENTITY_PROVIDER=htpasswd_auth # Default: htpasswd_auth
+#CONF_OPENSHIFT_MASTER_FILES=
+#CONF_OPENSHIFT_NODE_FILES=

--- a/provisioning/templates/ansible-hosts
+++ b/provisioning/templates/ansible-hosts
@@ -11,7 +11,7 @@ ansible_ssh_user=root
 osm_default_subdomain={{CLOUDAPPS_SUBDOMAIN}}
 
 # enable htpasswd authentication
-openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/openshift/openshift-passwd'}]
+openshift_master_identity_providers=[{{OPENSHIFT_IDENTITY_PROVIDER_JSON}}]
 
 # host group for masters
 [masters]

--- a/provisioning/templates/htpasswd_auth
+++ b/provisioning/templates/htpasswd_auth
@@ -1,0 +1,1 @@
+{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/openshift/openshift-passwd'}


### PR DESCRIPTION
#### What does this PR do?

In previous versions, we hard coded a basic htpasswd based authentication provider. This PR gives the user the ability to define thier own.
#### How should this be manually tested?
1. Test that defaults still work.

```
./provisioning/osc-provision --num-nodes=2 --key=<key>
```
1. Set up an LDAP provider

Create a file with the json code for your LDAP provider:

```
$ cat ldap_provider.json
{'name':'paas_ldap_provider','login':'true','challenge':'true','kind':'LDAPPasswordIdentityProvider','attributes':{'id':['dn'],'email':['mail'],'name':['displayName'],'preferredUsername':['uid']},'insecure':'false','ca':'/etc/pki/CA/certs/ipa-ca.crt','bindDN':'uid=ldap,cn=users,cn=compat,dc=rhc-ose,dc=labs,dc=redhat,dc=com','bindPassword':'<password>','url':'ldaps://<host>:636/dc=rhc-ose,dc=labs,dc=redhat,dc=com?uid?sub?(memberOf=cn=ose_users,cn=groups,cn=accounts,dc=rhc-ose,dc=labs,dc=redhat,dc=com)'}
```

Configure sample.cfg to load ldap provider json file and CA cert

```
## Platform Configs
#CONF_ENV_ID= # Default: random 8 character string
CONF_IMAGE_NAME=ose3-base # Default: ose3-base
CONF_SECURITY_GROUP_MASTER=ose3-master # Default: ose3-master
CONF_SECURITY_GROUP_NODE=ose3-node # Default: ose3-node
#CONF_LOGFILE=~/openstack_provision.log # Default: ~/openstack_provision.log
## OpenShift Configs
CONF_OPENSHIFT_BASE_DOMAIN=openshift.example.com # Default: ose.example.com
CONF_OPENSHIFT_CLOUDAPPS_SUBDOMAIN=cloudapps # Default: apps
CONF_PROVISION_COMPONENTS=openshift # Comman separated list. Supported values are: openshift,cicd. Default: openshift
CONF_OPENSHIFT_IDENTITY_PROVIDER=/root/repository/rhc-ose-env-configs/d1.rhc-ose.labs.redhat.com/files/paas_ldap_provider.json
CONF_OPENSHIFT_MASTER_FILES=/root/repository/rhc-ose-env-configs/d1.rhc-ose.labs.redhat.com/files/ipa-ca.crt:/etc/pki/CA/certs/ipa-ca.crt
```

Now run a provision with the above config file

```
./rhc-ose-etsauer/provisioning/osc-provision --num-nodes=2 --key=esauer --config=./rhc-ose-etsauer/provisioning/ldap_provider_env.cfg
```
#### Is there a relevant Issue open for this?

n/a
#### Who would you like to review this?

/cc @oybed
