### PR TITLE
updated openstack_image variable expression to fix docker_images syntax

### DIFF
--- a/provisioning/openstack-docker-client/run.sh
+++ b/provisioning/openstack-docker-client/run.sh
@@ -72,7 +72,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-OPENSTACK_IMAGE=$(${DOCKER_IMAGES} | awk '{ print $1 }' | grep ${OPENSTACK_CLIENT_IMAGE})
+OPENSTACK_IMAGE=$(echo -e "${DOCKER_IMAGES}" | awk '{ print $1 }' | grep ${OPENSTACK_CLIENT_IMAGE})
 
 if [ $? -gt 1 ]; then
   echo "Error: Failed to parse the Docker images to find ${OPENSTACK_CLIENT_IMAGE} image."


### PR DESCRIPTION
#### What does this PR do?

This PR fixes the syntax issue with the OPENSHIFT_IMAGES variable expression that was missed in the previous docker client run fix.
#### How should this be manually tested?

1 execute `./run.sh` and check for build or errors and verify startup
2 remove <b>rhtconsulting/rhc-openstack-client</b> image `docker rmi <id_of_image>`
3 execute `./run.sh` and watch for docker build or errors and verify startup
4 execute `./run.sh` again and verify docker build does not occur and startup successfully
#### Is there a relevant Issue open for this?

Related to PR #52, but this is closed.
#### Who would you like to review this?

/cc @sabre1041 
