### PR TITLE
Fixed link on line 37

### DIFF
--- a/provisioning/README.adoc
+++ b/provisioning/README.adoc
@@ -34,7 +34,7 @@ Current implementations:
 
 === Basic Provisioning Instructions
 
-1. link:provisioning/openstack/README.md[Configure client tools]
+1. link:openstack/README.md[Configure client tools]
 2. Clone this repo.
 3. Run osc-provision with no options to show Usage output and options
 +


### PR DESCRIPTION
The link on line 37 had two instances of the word "provision" which created a broken link.
