### PR TITLE
Support provisioning of different OpenStack flavors

### DIFF
--- a/provisioning/README.adoc
+++ b/provisioning/README.adoc
@@ -65,6 +65,7 @@ You can use the `--config=<file>` option to pass in a configuration file that ca
 ## Platform Configs
 CONF_ENV_ID= # Default: random 8 character string
 CONF_IMAGE_NAME=ose3-base # Default: ose3-base
+CONF_OS_FLAVOR=m1.large # Default: m1.medium
 CONF_SECURITY_GROUP_MASTER=ose3-master # Default: ose3-master
 CONF_SECURITY_GROUP_NODE=ose3-node # Default: ose3-node
 CONF_LOGFILE=~/openstack_provision.log # Default: ~/openstack_provision.log

--- a/provisioning/lib/constants
+++ b/provisioning/lib/constants
@@ -11,6 +11,7 @@ openshift_users="joe:redhat alice:redhat"
 openshift_zones=("east" "west")
 openshift_identity_provider=htpasswd_auth
 openshift_identity_provider_json="{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '\/etc\/openshift\/openshift-passwd'}"
+os_flavor="m1.medium"
 master_is_node=true
 platform="openstack" # Only one we support
 image_name="ose3-base"

--- a/provisioning/osc-provision
+++ b/provisioning/osc-provision
@@ -189,6 +189,7 @@ provision_masters() {
   command="${SCRIPT_BASE_DIR}/${platform}/provision.sh \
   --instance-name ${instance_name} \
   --key ${key} \
+  --flavor ${OS_FLAVOR} \
   --image-name ${IMAGE_NAME} \
   --security-groups ${SECURITY_GROUP_MASTER} \
   --add-volume ${VOLUME_SIZE} \
@@ -202,6 +203,7 @@ provision_nodes() {
   command="${SCRIPT_BASE_DIR}/${platform}/provision.sh \
   --instance-name ${instance_name} \
   --key ${key} \
+  --flavor ${OS_FLAVOR} \
   --image-name ${IMAGE_NAME} \
   --security-groups ${SECURITY_GROUP_NODE} \
   --num-instances $num_of_nodes \
@@ -271,6 +273,7 @@ SECURITY_GROUP_NODE=${CONF_SECURITY_GROUP_NODE:-$security_group_node}
 SECURITY_GROUP_CICD=${CONF_SECURITY_GROUP_CICD:-$security_group_cicd}
 LOGFILE=${CONF_LOGFILE:-$logfile}
 OPENSHIFT_BASE_DOMAIN=${CONF_OPENSHIFT_BASE_DOMAIN:-$openshift_base_domain}
+OS_FLAVOR=${CONF_OS_FLAVOR:-$os_flavor}
 PROVISION_COMPONENTS=${CONF_PROVISION_COMPONENTS:-$provision_components}
 VOLUME_SIZE=${CONF_VOLUME_SIZE:-$storage_volume_size}
 OPENSHIFT_MASTER_FILES="${CONF_OPENSHIFT_MASTER_FILES}"

--- a/provisioning/sample.cfg
+++ b/provisioning/sample.cfg
@@ -1,6 +1,7 @@
 ## Platform Configs
 #CONF_ENV_ID= # Default: random 8 character string
 CONF_IMAGE_NAME=ose3-base # Default: ose3-base
+CONF_OS_FLAVOR=m1.large # Default: m1.medium
 CONF_SECURITY_GROUP_MASTER=ose3-master # Default: ose3-master
 CONF_SECURITY_GROUP_NODE=ose3-node # Default: ose3-node
 #CONF_LOGFILE=~/openstack_provision.log # Default: ~/openstack_provision.log


### PR DESCRIPTION
#### What does this PR do?

This change enables the use of flavors when doing the provisioning. For now, two flavors are supported, m1.medium and m1.large, as these make sense at the moment. However, additional flavors can be added as needed.
*\* **_NOTE:**_ *\* The default flavor is now set to "m1.medium" - i.e.: a change from the m1.large as used before. 

_A separate PR will be submitted to update the d1/p1 configuration files._
#### How should this be manually tested?

Run a normal provisioning, i.e.: "./osc-provision --num-nodes=2 --key=<public_key>"

To test running a different flavor, set the "CONF_OS_FLAVOR" in a configuration file and use the --config command line option to run the provisioning, i.e.: "./osc-provision --num-nodes=2 --key=<public_key> --config=<config_file>"
#### Is there a relevant Issue open for this?

N/A
#### Who would you like to review this?

/cc @etsauer 
