### PR TITLE
Updated the jekyll-asciidoc-docker to support running as a Jenkins slave

### DIFF
--- a/docker/jekyll-asciidoc-docker/Dockerfile
+++ b/docker/jekyll-asciidoc-docker/Dockerfile
@@ -4,10 +4,18 @@ MAINTAINER Andrew Block “andrew.block@redhat.com”
 
 # Update System and install clients
 RUN yum update -y; \
-	yum install -y epel-release git tar libyaml-devel autoconf gcc-c++ readline-devel zlib-devel libffi-devel openssl-devel automake libtool bison sqlite-devel; \
+	yum install -y epel-release git tar java-1.8.0-openjdk libyaml-devel openssh-server autoconf gcc-c++ readline-devel zlib-devel libffi-devel openssl-devel automake libtool bison sqlite-devel; \
 	yum install -y nodejs; \
  	yum clean all; \
-	curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh | bash; \
+	useradd builder; \
+	echo "builder:builder" | chpasswd;
+
+ADD bin/start.sh /home/builder/
+
+RUN echo "export BUNDLE_PATH=/home/builder/bundle" >> /home/builder/.bash_profile; \
+    ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''; \
+    chown builder:builder /home/builder/start.sh; \
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh | bash; \
 	bash -c "source /root/.nvm/install.sh"; \
 	gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3; \
 	curl -sSL https://get.rvm.io | bash -s stable; \
@@ -18,17 +26,14 @@ RUN	/bin/bash -l -c "rvm install 2.2.1";
 RUN	/bin/bash -l -c "rvm use 2.2.1";
 RUN	/bin/bash -l -c "rvm rubygems latest";
 RUN /bin/bash -l -c "gem install bundler";
-	
-ADD bin/start.sh /root/	
+
+ENV BUNDLE_PATH /home/builder/bundle
 
 # Expose port
-EXPOSE 4000
+EXPOSE 4000 22
 
 # Set /root as starting directory
-WORKDIR /root
-
-# Helper script
-ENTRYPOINT ["/bin/bash"]
+WORKDIR /home/builder
 
 # Start Command
-CMD ["--login", "/root/start.sh"]
+CMD ["/bin/bash", "--login", "/home/builder/start.sh"]

--- a/docker/jekyll-asciidoc-docker/bin/start.sh
+++ b/docker/jekyll-asciidoc-docker/bin/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SOURCE_DIR=/root/source
+SOURCE_DIR=/home/builder/source
 
 if [ ! -d "$SOURCE_DIR" ]; then
    echo "Error: Source volume not mounted or available"

--- a/docker/jekyll-asciidoc-docker/run.sh
+++ b/docker/jekyll-asciidoc-docker/run.sh
@@ -19,7 +19,7 @@ usage() {
      --name=<name>                 : Name of the assembled image (Default: rhtconsulting/jekyll-asciidoc)
      --keep                        : Whether to keep the the container after exiting
      --rebuild                     : Rebuilds the image if it already exists
-     --directory=<directory>       : Directory containing a repository to mount inside the container
+     --directory=<directory>       : Directory containing source code to mount inside the container
      --help                        : Show Usage Output
 	 "
 }
@@ -59,7 +59,7 @@ do
 done
 
 if [ -z ${DIRECTORY} ]; then
-	echo "Error: Directory not specified"
+	echo "Error: Source code directory not specified"
 	exit 1
 fi
 

--- a/docker/jekyll-asciidoc-docker/run.sh
+++ b/docker/jekyll-asciidoc-docker/run.sh
@@ -58,6 +58,15 @@ do
   esac
 done
 
+if [ -z ${DIRECTORY} ]; then
+	echo "Error: Directory not specified"
+	exit 1
+fi
+
+if [ ! -d ${DIRECTORY} ]; then
+	echo "Error: Could not locate specified repository directory"
+	exit 1
+fi
 
 DOCKER_IMAGES=$(docker images)
 
@@ -84,17 +93,8 @@ else
 	fi
 fi
 
-if [ -z ${DIRECTORY} ]; then
-	echo "Error: Directory not specified"
-	exit 1
-fi
 
-if [ ! -d ${DIRECTORY} ]; then
-	echo "Error: Could not locate specified repository directory"
-	exit 1
-fi
-
-DIRECTORY_VOLUME="-v ${DIRECTORY}:/root/source:z"
+DIRECTORY_VOLUME="-v ${DIRECTORY}:/home/builder/source:z"
 
 echo "Starting Jekyll Asciidoc Container...."
 echo


### PR DESCRIPTION
#### What does this PR do?

Enable jekyll-asciidoc-docker container to be used as a Jenkins slave for building `openshift-playbooks` in Jenkins
#### How should this be manually tested?
1. Navigate to the container folder (`docker/jekyll-asciidoc-docker`)
2. Build a new image
   
   ```
   docker build -t rhtconsulting/jekyll-asciidoc .
   ```
3. Run a new container
   
   ```
   docker run -it --rm -P rhtconsulting/jekyll-asciidoc /usr/sbin/sshd -D
   ```
4. Determine the port that has been assigned for SSH
   
   ```
   docker ps | grep rhtconsulting/jekyll-asciidoc`
   ```
5. Inspect the result. Look for the value preceded by ->22
   
   ```
   b6489098f923        rhtconsulting/jekyll-asciidoc   "/usr/sbin/sshd -D"   5 minutes ago       Up 5 minutes        0.0.0.0:32770->4000/tcp, 0.0.0.0:32771->22/tcp   goofy_stallman 
   ```

In this case, it is port **32771**

6.. Attempt to connect to the container via SSH

```
ssh -p 32771 builder@&lt;DOCKER_HOST&gt;
```
#### Is there a relevant Issue open for this?

None
#### Who would you like to review this?

/cc @etsauer 
