### PR TITLE
Added workaround for incorrectly populated ImageStreams

### DIFF
--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -222,12 +222,22 @@ do_post(){
   --service-account=router
 
   do_create_registry
-  ### Workarounds for current issues
+
+  ###########################################
+  ### Workarounds for current issues - START
 
   # Remove --insecure-registry flag set by ansible (https://github.com/openshift/openshift-ansible/issues/497)
   for node in ${NODE_HOSTNAMES//,/ }; do
     $SSH_CMD $node 'sed -i "s/--insecure-registry=172.30.0.0\/16//" /etc/sysconfig/docker && systemctl restart docker'
   done
+
+  # Re-load previous ImageStream definitions ... 
+  oc delete imagestreams --all -n openshift
+  oc create -n openshift -f ${SCRIPT_BASE_DIR}/templates/image-streams-rhel7-ose3_0_2.json
+  oc create -n openshift -f /usr/share/openshift/examples/xpaas-streams/jboss-image-streams.json
+
+  ### Workarounds for current issues - END
+  ###########################################
 }
 
 do_create_registry() {

--- a/provisioning/templates/image-streams-rhel7-ose3_0_2.json
+++ b/provisioning/templates/image-streams-rhel7-ose3_0_2.json
@@ -1,0 +1,249 @@
+{
+  "kind": "ImageStreamList",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "ruby",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "dockerImageRepository": "registry.access.redhat.com/openshift3/ruby-20-rhel7",
+        "tags": [
+          {
+            "name": "latest"
+          },
+          {
+            "name": "2.0",
+            "annotations": {
+              "description": "Build and run Ruby 2.0 applications",
+              "iconClass": "icon-ruby",
+              "tags": "builder,ruby",
+              "supports": "ruby:2.0,ruby",
+              "version": "2.0"
+            },
+            "from": {
+              "Kind": "ImageStreamTag",
+              "Name": "latest"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "nodejs",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "dockerImageRepository": "registry.access.redhat.com/openshift3/nodejs-010-rhel7",
+        "tags": [
+          {
+            "name": "latest"
+          },
+          {
+            "name": "0.10",
+            "annotations": {
+              "description": "Build and run NodeJS 0.10 applications",
+              "iconClass": "icon-nodejs",
+              "tags": "builder,nodejs",
+              "supports":"nodejs:0.10,nodejs:0.1,nodejs",
+              "version": "0.10"
+            },
+            "from": {
+              "Kind": "ImageStreamTag",
+              "Name": "latest"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "perl",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "dockerImageRepository": "registry.access.redhat.com/openshift3/perl-516-rhel7",
+        "tags": [
+          {
+            "name": "latest"
+          },
+          {
+            "name": "5.16",
+            "annotations": {
+              "description": "Build and run Perl 5.16 applications",
+              "iconClass": "icon-perl",
+              "tags": "builder,perl",
+              "supports":"perl:5.16,perl",
+              "version": "5.16"
+            },
+            "from": {
+              "Kind": "ImageStreamTag",
+              "Name": "latest"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "php",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "dockerImageRepository": "registry.access.redhat.com/openshift3/php-55-rhel7",
+        "tags": [
+          {
+            "name": "latest"
+          },
+          {
+            "name": "5.5",
+            "annotations": {
+              "description": "Build and run PHP 5.5 applications",
+              "iconClass": "icon-php",
+              "tags": "builder,php",
+              "supports":"php:5.5,php",
+              "version": "5.5"
+            },
+            "from": {
+              "Kind": "ImageStreamTag",
+              "Name": "latest"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "python",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "dockerImageRepository": "registry.access.redhat.com/openshift3/python-33-rhel7",
+        "tags": [
+          {
+            "name": "latest"
+          },
+          {
+            "name": "3.3",
+            "annotations": {
+              "description": "Build and run Python 3.3 applications",
+              "iconClass": "icon-python",
+              "tags": "builder,python",
+              "supports":"python:3.3,python",
+              "version": "3.3"
+            },
+            "from": {
+              "Kind": "ImageStreamTag",
+              "Name": "latest"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mysql",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "dockerImageRepository": "registry.access.redhat.com/openshift3/mysql-55-rhel7",
+        "tags": [
+          {
+            "name": "latest"
+          },
+          {
+            "name": "5.5",
+            "from": {
+              "Kind": "ImageStreamTag",
+              "Name": "latest"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "postgresql",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "dockerImageRepository": "registry.access.redhat.com/openshift3/postgresql-92-rhel7",
+        "tags": [
+          {
+            "name": "latest"
+          },
+          {
+            "name": "9.2",
+            "from": {
+              "Kind": "ImageStreamTag",
+              "Name": "latest"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mongodb",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "dockerImageRepository": "registry.access.redhat.com/openshift3/mongodb-24-rhel7",
+        "tags": [
+          {
+            "name": "latest"
+          },
+          {
+            "name": "2.4",
+            "from": {
+              "Kind": "ImageStreamTag",
+              "Name": "latest"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "jenkins",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "dockerImageRepository": "registry.access.redhat.com/openshift3/jenkins-1-rhel7",
+        "tags": [
+          {
+            "name": "latest"
+          },
+          {
+            "name": "1",
+            "from": {
+              "Kind": "ImageStreamTag",
+              "Name": "latest"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
#### What does this PR do?

This adds a workaround for the ImageStreams in the openshift-ansible installer which breaks features such as "oc new-app", etc.
#### How should this be manually tested?

Install the env from scratch ... using the rhc-ose tools ... then try loading an app from source, e.g.: 

```
>> oc new-app https://github.com/gshipley/smoke
```
#### Is there a relevant Issue open for this?

N/A
#### Who would you like to review this?

/cc @sabre1041 @etsauer 
