### PR TITLE
Fix docker jekyll rebuild option

### DIFF
--- a/docker/jekyll-asciidoc-docker/run.sh
+++ b/docker/jekyll-asciidoc-docker/run.sh
@@ -40,7 +40,7 @@ do
   	-n=*|--name=*)
       JEKYLL_DOCKER_IMAGE="${i#*=}"
       shift;;
-    -r=*|--rebuild=*)
+    -r|--rebuild)
       REBUILD="true"
 	  shift;;
   	-d=*|--directory=*)
@@ -82,15 +82,18 @@ if [ $? -gt 1 ]; then
   exit 1
 fi
 
+# Delete Image if image exists and rebuild indicated
+if [ ! -z $DOCKER_IMAGE ] && [ ! -z $REBUILD ]; then
+	echo "Removing ${JEKYLL_DOCKER_IMAGE} image...."
+	docker rmi -f ${JEKYLL_DOCKER_IMAGE}
+	DOCKER_IMAGE=
+fi
+
+
 # Check if Image has been build previously
 if [ -z $DOCKER_IMAGE ]; then
 	echo "Building Docker Image ${OPENSTACK_CLIENT_IMAGE}...."
 	docker build -t ${JEKYLL_DOCKER_IMAGE} ${SCRIPT_BASE_DIR}
-else
-	if [ ! -z $REBUILD ]; then
-		echo "Removing ${JEKYLL_DOCKER_IMAGE} image...."
-		docker rmi -f ${JEKYLL_DOCKER_IMAGE}
-	fi
 fi
 
 


### PR DESCRIPTION
#### What does this PR do?

Corrections rebuild options of the jekyll-asciidoc docker container
#### How should this be manually tested?

Build the jekyll-asciidoc container

```
./run.sh -d=<directory_of_source>
```

Once successful, invoke the rebuild option to rebuild the container

```
./run.sh -d=<directory_of_source> --rebuild
```

The image should be rebuilt

Validate the image is not rebuilt when _rebuild_ option is not specified

```
./run.sh -d=<directory_of_source>
```
#### Is there a relevant Issue open for this?

Provide a link to any open issues that describe the problem you are solving.
#81
#### Who would you like to review this?

/cc @etsauer 
