### PR TITLE
Updates to CICD install to support JDK 8 and new 3.1 image

### DIFF
--- a/provisioning/cicd-install
+++ b/provisioning/cicd-install
@@ -72,10 +72,16 @@ function check_prereqs() {
 function install_prereqs() {
 	
 	# EPEL and software packages	
-	yum install -y install http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm wget unzip git vim jq &>/dev/null || error_out "Failed to install prerequisite software" 2
+	yum install -y install http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm wget firewalld unzip git vim &>/dev/null || error_out "Failed to install initial prerequisite software" 2
 
 	# JQ must be installed only after EPEL installed
-	yum install -y install jq &>/dev/null || error_out "Failed to install prerequisite software" 2
+	yum install -y install jq &>/dev/null || error_out "Failed to install jq" 2
+	
+	# Configure Firewall
+	systemctl disable iptables
+	systemctl stop iptables
+	systemctl enable firewalld
+	systemctl start firewalld
 }
 
 #
@@ -83,8 +89,7 @@ function install_prereqs() {
 #
 
 function install_java_jdk() {
-   subscription-manager repos --enable rhel-7-server-eus-thirdparty-oracle-java-rpms
-   yum install -y java-1.7.0-oracle-devel &>/dev/null || error_out "Failed to install Java JDK" 3
+   yum --enablerepo=rhel-7-server-thirdparty-oracle-java-rpms install -y java-1.8.0-oracle-devel &>/dev/null || error_out "Failed to install Java JDK" 3
 }
 
 
@@ -191,8 +196,7 @@ function install_groovy() {
 
 function install_maven() {
 
-  yum install -y maven  &>/dev/null || error_out "Failed to install Maven" 4
-  
+  yum --enablerepo=rhel-7-server-optional-rpms install -y maven  &>/dev/null || error_out "Failed to install Maven" 4
   cp -f ${SCRIPT_BASE_DIR}/cicd/maven/settings.xml /usr/share/maven/conf/
 }
 


### PR DESCRIPTION
#### What does this PR do?

Adds JDK 8 support and to align with OpenStack 3.1 image
#### How should this be manually tested?

Create a custom configuration file 

```
## Platform Configs
#CONF_ENV_ID= # Default: random 8 character string
CONF_IMAGE_NAME=ose3_1-base # Default: ose3_0-base
CONF_OS_FLAVOR=m1.medium # Default: m1.medium
CONF_SECURITY_GROUP_MASTER=ose3-master # Default: ose3-master
CONF_SECURITY_GROUP_NODE=ose3-node # Default: ose3-node
#CONF_LOGFILE=~/openstack_provision.log # Default: ~/openstack_provision.log
## OpenShift Configs
CONF_OPENSHIFT_BASE_DOMAIN=ose.example.com # Default: ose.example.com
CONF_OPENSHIFT_CLOUDAPPS_SUBDOMAIN=apps # Default: apps
CONF_PROVISION_COMPONENTS=cicd # Comman separated list. Supported values are: openshift,cicd. Default: openshift
CONF_OPENSHIFT_IDENTITY_PROVIDER=htpasswd_auth # Default: htpasswd_auth
#CONF_OPENSHIFT_MASTER_FILES= # Example value: /path/to/source:/path/to/dest /path/to/source2:/path/to/dest2; Default is null
#CONF_OPENSHIFT_NODE_FILES= # Example value: /path/to/source:/path/to/dest /path/to/source2:/path/to/dest2; Default is null
```

Provision the CICD server

```
./osc-provision --config=<path_to_cfg_file> --key=<openstack_keyname>
```

Validate Maven and JDK Installed successfully

```
mvn -v
```

Should result in the following

```
Apache Maven 3.0.5 (Red Hat 3.0.5-16)
Maven home: /usr/share/maven
Java version: 1.8.0_65, vendor: Oracle Corporation
Java home: /usr/lib/jvm/java-1.8.0-oracle-1.8.0.65-1jpp.3.el7_1.x86_64/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "3.10.0-327.el7.x86_64", arch: "amd64", family: "unix"
```
#### Is there a relevant Issue open for this?
#83
#### Who would you like to review this?

/cc @JaredBurck 
