### PR TITLE
Fixing several broken links in documentation

### DIFF
--- a/provisioning/README.adoc
+++ b/provisioning/README.adoc
@@ -34,7 +34,7 @@ Current implementations:
 
 === Basic Provisioning Instructions
 
-1. link:provisioning/openstack/README.md[Configure client tools]
+1. link:/provisioning/openstack/README.md[Configure client tools]
 2. Clone this repo.
 3. Run osc-provision with no options to show Usage output and options
 +
@@ -71,7 +71,7 @@ CONF_SECURITY_GROUP_NODE=ose3-node # Default: ose3-node
 CONF_LOGFILE=~/openstack_provision.log # Default: ~/openstack_provision.log
 CONF_STORAGE_DISK_VOLUME=/dev/vdb # The disk path (within an instance) for the "extra" storage volume used by OSE/Docker (see below) # Default: /dev/vdb
 CONF_VOLUME_SIZE=25 # Allocate a 25 GB volume for a shared OpenShift / Docker disk (see "CONF_STORAGE_SIZE_OSE" below - OSE uses the first X GB and leaves the rest for Docker storage) # Default: 10 GB
-CONF_STORAGE_SIZE_OSE=4 # Allocate 4 GB for the OpenShift partition (e.g.: /var/lib/openshift) # Default: 2 GB 
+CONF_STORAGE_SIZE_OSE=4 # Allocate 4 GB for the OpenShift partition (e.g.: /var/lib/openshift) # Default: 2 GB
 CONF_STORAGE_SIZE_LOGGING=4 # Allocate 4 GB for logs (e.g.: /var/log) # Default: 0 GB - i.e.: shared with root (/) partition
 ## OpenShift Configs
 CONF_OPENSHIFT_BASE_DOMAIN=openshift.example.com # Default: ose.example.com

--- a/provisioning/openstack/README.md
+++ b/provisioning/openstack/README.md
@@ -21,7 +21,7 @@ export OS_PASSWORD=mypassword
 ```
 NOTE: We will be switching to tokenized auth as soon as its supported in our environment, so as not to require storing passwords in text files.
 1. Install Openstack client packages
- * Option 1 (recommended): Setup the [OpenStack Docker Client](provisioning/openstack-docker-client/)
+ * Option 1 (recommended): Setup the [OpenStack Docker Client](/docker/openstack-docker-client)
  * Option 2: Install the nova client tools to your local machine.  Instructions can be found [here]( http://docs.openstack.org/user-guide/common/cli_install_openstack_command_line_clients.html#installing-from-packages).
 
 ## Create an Instance ##


### PR DESCRIPTION
#### What does this PR do?

Fix broken link in provisioning README
#### How should this be manually tested?

Click 'Configure Client Tools' link in the Provisioning README
Click 'OpenStack Docker Client' link in the Configure Client Tools README
#### Is there a relevant Issue open for this?

https://github.com/rhtconsulting/rhc-ose/issues/79
#### Who would you like to review this?

/cc @sabre1041 @oybed @JaredBurck @jradtke-rh @jmarley
