### PR TITLE
Updates to CICD software and plugins

### DIFF
--- a/provisioning/cicd-install
+++ b/provisioning/cicd-install
@@ -181,6 +181,7 @@ function install_jenkins() {
   install_jenkins_plugin 'script-security' '1.15'
   install_jenkins_plugin 'durable-task' '1.7'
   install_jenkins_plugin 'docker-plugin' '0.16.0'
+  install_jenkins_plugin 'openshift-pipeline' '1.0.4'
   
   install_pinned_jenkins_plugin 'credentials' '1.24'
   install_pinned_jenkins_plugin 'cvs' '2.12'

--- a/provisioning/cicd-install
+++ b/provisioning/cicd-install
@@ -18,7 +18,7 @@ set -e
 
 CICD_SETUP_DIR=/tmp/cicd-setup
 CLOUD_ENV=0
-NEXUS_VERSION=2.11.4-01
+NEXUS_VERSION=2.12.0-01
 GROOVY_VERSION=2.4.4
 DOCKER_VOLUME=/dev/vdb
 
@@ -110,6 +110,26 @@ function install_jenkins_plugin() {
 	
 }
 
+#
+# Function to install additional Jenkins pinned plugins
+#
+# Parameters:
+# $1 - Name of the Jenkins plugin
+# $2 - Version of the Jenkins plugin
+#
+
+function install_pinned_jenkins_plugin() {
+	
+	plugin_name=${1}
+	plugin_version=${2}
+	
+	install_jenkins_plugin $plugin_name $plugin_version
+
+    mv /var/lib/jenkins/plugins/$plugin_name.hpi /var/lib/jenkins/plugins/$plugin_name.jpi
+    touch /var/lib/jenkins/plugins/$plugin_name.jpi.pinned
+	
+}
+
 
 #
 # Function to install and configure the Jenkins CI server
@@ -133,37 +153,52 @@ function install_jenkins() {
   # Install plugins
   mkdir -p /var/lib/jenkins/plugins
   
-  install_jenkins_plugin 'github' '1.13.1'
-  install_jenkins_plugin 'github-api' '1.69'
-  install_jenkins_plugin 'git' '2.4.0'
-  install_jenkins_plugin 'git-client' '1.18.0'
-  install_jenkins_plugin 'credentials' '1.23'
-  install_jenkins_plugin 'scm-api' '0.2'
-  install_jenkins_plugin 'credentials-binding' '1.5'
+  install_jenkins_plugin 'github' '1.14.2'
+  install_jenkins_plugin 'github-api' '1.71'
+  install_jenkins_plugin 'git' '2.4.1'
+  install_jenkins_plugin 'git-client' '1.19.1'
+  install_jenkins_plugin 'credentials' '1.24'
+  install_jenkins_plugin 'scm-api' '1.0'
+  install_jenkins_plugin 'credentials-binding' '1.6'
   install_jenkins_plugin 'plain-credentials' '1.1'
-  install_jenkins_plugin 'workflow-step-api' '1.9'
-  install_jenkins_plugin 'parameterized-trigger' '2.28'
-  install_jenkins_plugin 'matrix-project' '1.4.1'
-  install_jenkins_plugin 'promoted-builds' '2.21'
+  install_jenkins_plugin 'workflow-step-api' '1.12'
+  install_jenkins_plugin 'parameterized-trigger' '2.30'
+  install_jenkins_plugin 'matrix-project' '1.6'
+  install_jenkins_plugin 'promoted-builds' '2.24.1'
   install_jenkins_plugin 'rebuild' '1.25'
-  install_jenkins_plugin 'subversion' '1.54'
-  install_jenkins_plugin 'scm-api' '0.2'
-  install_jenkins_plugin 'ssh-credentials' '1.10'
+  install_jenkins_plugin 'scm-api' '1.0'
+  install_jenkins_plugin 'ssh-credentials' '1.11'
   install_jenkins_plugin 'mapdb-api' '1.0.6.0'
-  install_jenkins_plugin 'build-pipeline-plugin' '1.4.7'  
+  install_jenkins_plugin 'build-pipeline-plugin' '1.4.9'  
   install_jenkins_plugin 'jquery' '1.11.2-0'
-  install_jenkins_plugin 'delivery-pipeline-plugin' '0.9.7'
-  install_jenkins_plugin 'token-macro' '1.10'
+  install_jenkins_plugin 'delivery-pipeline-plugin' '0.9.8'
+  install_jenkins_plugin 'token-macro' '1.12.1'
   install_jenkins_plugin 'ws-cleanup' '0.28'
-  install_jenkins_plugin 'job-dsl' '1.37'
-  install_jenkins_plugin 'cloudbees-folder' '4.9'
+  install_jenkins_plugin 'job-dsl' '1.41'
+  install_jenkins_plugin 'cloudbees-folder' '5.1'
   install_jenkins_plugin 'groovy' '1.27'
-  install_jenkins_plugin 'groovy-postbuild' '2.2.1'
+  install_jenkins_plugin 'groovy-postbuild' '2.2.2'
   install_jenkins_plugin 'script-security' '1.15'
+  install_jenkins_plugin 'durable-task' '1.7'
+  install_jenkins_plugin 'docker-plugin' '0.16.0'
   
-  # Manual corrections for credentials plugin
-  mv /var/lib/jenkins/plugins/credentials.hpi /var/lib/jenkins/plugins/credentials.jpi
-  touch /var/lib/jenkins/plugins/credentials.jpi.pinned
+  install_pinned_jenkins_plugin 'credentials' '1.24'
+  install_pinned_jenkins_plugin 'cvs' '2.12'
+  install_pinned_jenkins_plugin 'javadoc' '1.3'
+  install_pinned_jenkins_plugin 'junit' '1.10'
+  install_pinned_jenkins_plugin 'mailer' '1.16'
+  install_pinned_jenkins_plugin 'matrix-auth' '1.2'
+  install_pinned_jenkins_plugin 'matrix-project' '1.6'
+  install_pinned_jenkins_plugin 'maven-plugin' '2.12.1'
+  install_pinned_jenkins_plugin 'antisamy-markup-formatter' '1.3'
+  install_pinned_jenkins_plugin 'pam-auth' '1.2'
+  install_pinned_jenkins_plugin 'script-security' '1.15'
+  install_pinned_jenkins_plugin 'ssh-credentials' '1.11'
+  install_pinned_jenkins_plugin 'ssh-slaves' '1.10'
+  install_pinned_jenkins_plugin 'translation' '1.12'
+  install_pinned_jenkins_plugin 'subversion' '2.5.5'
+  install_pinned_jenkins_plugin 'windows-slaves' '1.1'
+
 
   chown -R jenkins:jenkins /var/lib/jenkins
   

--- a/provisioning/cicd/jenkins/hudson.plugins.git.GitTool.xml
+++ b/provisioning/cicd/jenkins/hudson.plugins.git.GitTool.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<hudson.plugins.git.GitTool_-DescriptorImpl plugin="git-client@1.17.1">
+<hudson.plugins.git.GitTool_-DescriptorImpl plugin="git-client@1.19.1">
   <installations class="hudson.plugins.git.GitTool-array">
     <hudson.plugins.git.GitTool>
       <name>Default</name>

--- a/provisioning/cicd/nexus/nexus.xml
+++ b/provisioning/cicd/nexus/nexus.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nexusConfiguration>
   <version>2.8.0</version>
-  <nexusVersion>2.11.3-01</nexusVersion>
+  <nexusVersion>2.12.0-01</nexusVersion>
   <globalConnectionSettings>
     <connectionTimeout>20000</connectionTimeout>
     <retrievalRetryCount>3</retrievalRetryCount>


### PR DESCRIPTION
#### What does this PR do?

Updates to the latest set of tools and plugins for CICD environment provisioning. Jenkins DSL tooling for demos have also been [updated](https://github.com/rhtconsulting/ose-jenkins-job-dsl/compare/workflow-dsl-upgrade) and can be merged to master once these updates have been appllied
#### How should this be manually tested?

Pull down this PR and use the method of your choosing to provision a new CICD instance in OpenStack

Create a new configuration file with at least the following contents

```
CONF_IMAGE_NAME=ose3_1-base
CONF_PROVISION_COMPONENTS=cicd
```

Provision the new environment:

```
./osc-provision --config=<config_file> --key=<ssh-key> --ose-version=3.1
```
#### Is there a relevant Issue open for this?

No
#### Who would you like to review this?

/cc @etsauer  @JaredBurck 
