### PR TITLE
Updates to support configuration of cicd environment driven by conf file

### DIFF
--- a/provisioning/README.adoc
+++ b/provisioning/README.adoc
@@ -77,7 +77,7 @@ CONF_STORAGE_SIZE_LOGGING=4 # Allocate 4 GB for logs (e.g.: /var/log) # Default:
 ## OpenShift Configs
 CONF_OPENSHIFT_BASE_DOMAIN=openshift.example.com # Default: ose.example.com
 CONF_OPENSHIFT_CLOUDAPPS_SUBDOMAIN=cloudapps # Default: apps (generates "apps.ose.example.com")
-CONF_PROVISION_COMPONENTS=openshift # Comman separated list. Supported values are: openshift,cicd. Default: openshift
+CONF_PROVISION_COMPONENTS=openshift # Comma separated list. Supported values are: openshift,cicd. Default: openshift
 ----
 
 ==== Provisioning a CICD Server

--- a/provisioning/cicd-install
+++ b/provisioning/cicd-install
@@ -90,6 +90,15 @@ function install_prereqs() {
 
 function install_java_jdk() {
    yum --enablerepo=rhel-7-server-thirdparty-oracle-java-rpms install -y java-1.8.0-oracle-devel &>/dev/null || error_out "Failed to install Java JDK" 3
+
+   if [ -n "${CONF_JAVA_CERTS}" ]; then
+	   jre_root=$(alternatives --list | grep jre_oracle | awk '{ print $3 }')
+ 	  for file in $(echo ${CONF_JAVA_CERTS} | tr "," " "); do
+ 	    source=${file%:*}
+ 	    dest=${file#*:}
+ 	    keytool -import -trustcacerts -alias $(basename $dest) -file $dest -keystore $jre_root/lib/security/cacerts -storepass changeit -noprompt
+ 	  done
+   fi
 }
 
 
@@ -142,6 +151,10 @@ function install_jenkins() {
   yum install -y jenkins  &>/dev/null || error_out "Failed to install Jenkins" 5
   
   cp -R ${SCRIPT_BASE_DIR}/cicd/jenkins/* /var/lib/jenkins
+
+  jenkins_config_file="$(process_template ${SCRIPT_BASE_DIR}/templates/config.xml JENKINS_AUTHZ_XML)"
+
+  echo $jenkins_config_file > /var/lib/jenkins/config.xml
 
   # Update Jenkins context
   sed -i "s/JENKINS_ARGS=\"\"/JENKINS_ARGS=\"--prefix=\/jenkins\"/g" /etc/sysconfig/jenkins
@@ -253,6 +266,16 @@ function install_nexus() {
   mkdir -p /usr/local/sonatype-work/nexus/conf
   cp -f ${SCRIPT_BASE_DIR}/cicd/nexus/nexus.xml /usr/local/sonatype-work/nexus/conf/
   
+  # Copy Custom Configurations
+  if [ -n "${CONF_CICD_NEXUS_CONFIG_FILES}" ]; then
+    for file in $(echo ${CONF_CICD_NEXUS_CONFIG_FILES} | tr "," " "); do
+      dest=${file#*:}
+      cp -f $dest /usr/local/sonatype-work/nexus/conf/
+    done
+
+  fi
+
+
   chown -R nexus:nexus /usr/local/nexus* /usr/local/sonatype-work /var/run/nexus
 
   sed -i "s/NEXUS_HOME=\"..\"/NEXUS_HOME=\"\/usr\/local\/nexus\"/g" /usr/local/nexus/bin/nexus
@@ -340,6 +363,8 @@ EOF
 	systemctl enable docker
 }
 
+# Configuring Variables
+JENKINS_AUTHZ_XML=${CONF_JENKINS_AUTHZ_XML:=jenkins_authz_xml}
 
 echo "===================================="
 echo "=   Installing CI/CD Environment   ="

--- a/provisioning/lib/constants
+++ b/provisioning/lib/constants
@@ -53,3 +53,7 @@ no_install=false
 action="provision"
 provision_components="openshift"
 
+jenkins_authz="jenkins-unsecured-authz"
+jenkins_authz_xml="<authorizationStrategy class=\"hudson.security.AuthorizationStrategy\$Unsecured\"\/><securityRealm class="hudson.security.SecurityRealm\$None"\/>"
+
+

--- a/provisioning/lib/helpers
+++ b/provisioning/lib/helpers
@@ -276,3 +276,19 @@ setup_logging_storage() {
   return 0
 }
 
+sync_files() {
+  # Sync files from variable with format "file1:dest1 file2:dest2"
+  files=$1
+  nodes=$2
+
+  # TODO: it may become necessary to support setting ownership, permissions, and SELinux context
+  for node in $nodes; do
+    for file in $files; do
+      source=${file%:*}
+      dest=${file#*:}
+	  dest_dir=$(dirname $dest)
+      ${SSH_CMD} root@${node} "mkdir -p $dest_dir" && ${SCP_CMD} ${source} root@${node}:${dest}
+    done
+  done
+}
+

--- a/provisioning/lib/helpers
+++ b/provisioning/lib/helpers
@@ -61,16 +61,37 @@ process_configfile() {
   # handle special cases
 
   # Setup user-defined auth Provider
-  if [ -f ${CONF_OPENSHIFT_IDENTITY_PROVIDER} ]; then
-    # User is providing a file containing custom auth provider, load it
-    CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON=$(cat ${CONF_OPENSHIFT_IDENTITY_PROVIDER} | sed -e 's/[\/&]/\\&/g')
-  else
-    # Use the matching provider in templates directory
-    CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON=$(cat ${SCRIPT_BASE_DIR}/templates/${CONF_OPENSHIFT_IDENTITY_PROVIDER} | sed -e 's/[\/&]/\\&/g')
+  if [ ! -z ${CONF_OPENSHIFT_IDENTITY_PROVIDER} ]; then
+    
+	if [ -f ${CONF_OPENSHIFT_IDENTITY_PROVIDER} ]; then
+      # User is providing a file containing custom auth provider, load it
+      CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON=$(cat ${CONF_OPENSHIFT_IDENTITY_PROVIDER} | sed -e 's/[\/&]/\\&/g')
+    else
+      # Use the matching provider in templates directory
+      CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON=$(cat ${SCRIPT_BASE_DIR}/templates/${CONF_OPENSHIFT_IDENTITY_PROVIDER} | sed -e 's/[\/&]/\\&/g')
+    fi
+	
+    CONF_ENVIRONMENT="${CONF_ENVIRONMENT}export CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON=\"${CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON}\""$'\n'
+    export CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON="${CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON}"
+
+  fi
+  
+  # Setup user-defined Jenkins authz
+  if [ ! -z ${CONF_JENKINS_AUTHZ} ]; then
+
+    if [ -f ${CONF_JENKINS_AUTHZ} ]; then
+      # User is providing a file containing custom Jenkins Authentication/Authorization, load it
+      CONF_JENKINS_AUTHZ_XML=$(cat ${CONF_JENKINS_AUTHZ} | sed -e 's/[\/&/$\\"]/\\&/g')
+    else
+      # Use the matching provider in templates directory
+      CONF_JENKINS_AUTHZ_XML=$(cat ${SCRIPT_BASE_DIR}/templates/${CONF_JENKINS_AUTHZ} | sed -e 's/[\/&/$\\"]/\\&/g')
+    fi
+	
+    CONF_ENVIRONMENT="${CONF_ENVIRONMENT}export CONF_JENKINS_AUTHZ_XML=\"${CONF_JENKINS_AUTHZ_XML}\""$'\n'
+    export CONF_JENKINS_AUTHZ_XML="${CONF_JENKINS_AUTHZ_XML}"
+
   fi
 
-  CONF_ENVIRONMENT="${CONF_ENVIRONMENT}export CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON=\"${CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON}\""$'\n'
-  export CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON="${CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON}"
 }
 
 ## Template Format ##
@@ -97,7 +118,7 @@ process_template() {
   local output="$(cat $template_file)"
 
   for var in $vars; do
-    value=${!var}
+    value=$(echo "${!var}" | sed -e 's/[$"]/\\&/g')
     echo "${value}" > /tmp/${var}
     output=$(echo "$output" | perl -pe "s/{{$var}}/${value}/g")
   done

--- a/provisioning/osc-provision
+++ b/provisioning/osc-provision
@@ -77,21 +77,13 @@ install_cicd() {
 
   # Copy Nexus Configuration Files
   if [ -n "${CONF_CICD_NEXUS_CONFIG_FILES}" ]; then
-	  for file in $(echo ${CONF_CICD_NEXUS_CONFIG_FILES} | tr "," " "); do
-	    source=${file%:*}
-	    dest=${file#*:}
-	    ${SCP_CMD} ${source} root@${cicd_public}:${dest}
-	  done
+      sync_files "${CONF_CICD_NEXUS_CONFIG_FILES//,/ }" "${cicd_public}"
   fi
 
 
   # Copy Java Certificates Files
   if [ -n "${CONF_JAVA_CERTS}" ]; then
-	  for file in $(echo ${CONF_JAVA_CERTS} | tr "," " "); do
-	    source=${file%:*}
-	    dest=${file#*:}
-	    ${SCP_CMD} ${source} root@${cicd_public}:${dest}
-	  done
+	  sync_files "${CONF_JAVA_CERTS//,/ }" "${cicd_public}"
   fi
 
   ${SSH_CMD} root@${cicd_public} "$CONF_ENVIRONMENT bash${bash_opts} ~/${REPO_BASE_NAME}/provisioning/cicd-install"
@@ -239,21 +231,6 @@ provision_nodes() {
   --n \
   --debug"
   $command || error_out "Node Provision failed. See log at ${LOGFILE}." ${ERROR_CODE_PROVISION_FAILURE}
-}
-
-sync_files() {
-  # Sync files from variable with format "file1:dest1 file2:dest2"
-  files=$1
-  nodes=$2
-
-  # TODO: it may become necessary to support setting ownership, permissions, and SELinux context
-  for node in $nodes; do
-    for file in $files; do
-      source=${file%:*}
-      dest=${file#*:}
-      ${SCP_CMD} ${source} root@${node}:${dest}
-    done
-  done
 }
 
 source ${SCRIPT_BASE_DIR}/lib/error_codes

--- a/provisioning/osc-provision
+++ b/provisioning/osc-provision
@@ -75,6 +75,25 @@ install_cicd() {
     tar cf - ${REPO_BASE_NAME} | ${SSH_CMD} root@${cicd_public} tar xf -
   popd >/dev/null
 
+  # Copy Nexus Configuration Files
+  if [ -n "${CONF_CICD_NEXUS_CONFIG_FILES}" ]; then
+	  for file in $(echo ${CONF_CICD_NEXUS_CONFIG_FILES} | tr "," " "); do
+	    source=${file%:*}
+	    dest=${file#*:}
+	    ${SCP_CMD} ${source} root@${cicd_public}:${dest}
+	  done
+  fi
+
+
+  # Copy Java Certificates Files
+  if [ -n "${CONF_JAVA_CERTS}" ]; then
+	  for file in $(echo ${CONF_JAVA_CERTS} | tr "," " "); do
+	    source=${file%:*}
+	    dest=${file#*:}
+	    ${SCP_CMD} ${source} root@${cicd_public}:${dest}
+	  done
+  fi
+
   ${SSH_CMD} root@${cicd_public} "$CONF_ENVIRONMENT bash${bash_opts} ~/${REPO_BASE_NAME}/provisioning/cicd-install"
 }
 
@@ -275,6 +294,7 @@ do
       ;;
   esac
 done
+
 
 # Set up environment based on default values and User input
 

--- a/provisioning/templates/config.xml
+++ b/provisioning/templates/config.xml
@@ -5,8 +5,7 @@
   <numExecutors>2</numExecutors>
   <mode>NORMAL</mode>
   <useSecurity>true</useSecurity>
-  <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
-  <securityRealm class="hudson.security.SecurityRealm$None"/>
+  {{JENKINS_AUTHZ_XML}}
   <disableRememberMe>false</disableRememberMe>
   <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
   <workspaceDir>${ITEM_ROOTDIR}/workspace</workspaceDir>

--- a/provisioning/templates/jenkins-unsecured-authz
+++ b/provisioning/templates/jenkins-unsecured-authz
@@ -1,0 +1,1 @@
+<authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/><securityRealm class="hudson.security.SecurityRealm$None"/>


### PR DESCRIPTION
#### What does this PR do?

Allows for the cicd environment to be driven by values in a configuration file
#### How should this be manually tested?

Create a file (single line) containing your Jenkins security configurations (`/root/repository/rhc-ose-env-configs/openshift_environments/cicd.rhc-ose.labs.redhat.com/files/jenkins-ldap-authz.xml`)

```
<authorizationStrategy class="hudson.security.ProjectMatrixAuthorizationStrategy"><permission>com.cloudbees.plugins.credentials.CredentialsProvider.Create:ci_users</permission><permission>com.cloudbees.plugins.credentials.CredentialsProvider.Delete:ci_users</permission><permission>com.cloudbees.plugins.credentials.CredentialsProvider.ManageDomains:ci_users</permission><permission>com.cloudbees.plugins.credentials.CredentialsProvider.Update:ci_users</permission><permission>com.cloudbees.plugins.credentials.CredentialsProvider.View:ci_users</permission><permission>hudson.model.Computer.Build:ci_users</permission><permission>hudson.model.Computer.Configure:ci_users</permission><permission>hudson.model.Computer.Connect:ci_users</permission><permission>hudson.model.Computer.Create:ci_users</permission><permission>hudson.model.Computer.Delete:ci_users</permission><permission>hudson.model.Computer.Disconnect:ci_users</permission><permission>hudson.model.Hudson.Administer:ci_admins</permission><permission>hudson.model.Hudson.Read:ci_users</permission><permission>hudson.model.Item.Build:ci_users</permission><permission>hudson.model.Item.Cancel:ci_users</permission><permission>hudson.model.Item.Configure:ci_users</permission><permission>hudson.model.Item.Create:ci_users</permission><permission>hudson.model.Item.Delete:ci_users</permission><permission>hudson.model.Item.Discover:ci_users</permission><permission>hudson.model.Item.Move:ci_users</permission><permission>hudson.model.Item.Read:ci_users</permission><permission>hudson.model.Item.Workspace:ci_users</permission><permission>hudson.model.Run.Delete:ci_users</permission><permission>hudson.model.Run.Update:ci_users</permission><permission>hudson.model.View.Configure:ci_users</permission><permission>hudson.model.View.Create:ci_users</permission><permission>hudson.model.View.Delete:ci_users</permission><permission>hudson.model.View.Read:ci_users</permission><permission>hudson.scm.SCM.Tag:ci_users</permission></authorizationStrategy><securityRealm class="hudson.security.LDAPSecurityRealm"><server>ldaps://ipa.rhc-ose.labs.redhat.com:636</server><rootDN>dc=rhc-ose,dc=labs,dc=redhat,dc=com</rootDN><inhibitInferRootDN>false</inhibitInferRootDN><userSearchBase>cn=users,cn=accounts</userSearchBase><userSearch>uid={0}</userSearch><groupMembershipStrategy class="jenkins.security.plugins.ldap.FromUserRecordLDAPGroupMembershipStrategy"/><managerDN>uid=ldap,cn=users,cn=compat,dc=rhc-ose,dc=labs,dc=redhat,dc=com</managerDN><managerPassword>OMITTED</managerPassword><disableMailAddressResolver>false</disableMailAddressResolver><displayNameAttributeName>displayname</displayNameAttributeName><mailAddressAttributeName>mail</mailAddressAttributeName><userIdStrategy class="jenkins.model.IdStrategy$CaseInsensitive"/><groupIdStrategy class="jenkins.model.IdStrategy$CaseInsensitive"/></securityRealm>
```

Create supporting Nexus configurations (`/root/repository/rhc-ose-env-configs/openshift_environments/cicd.rhc-ose.labs.redhat.com/files/nexus-ldap.xml`)

```
<?xml version="1.0" encoding="UTF-8"?>
<ldapConfiguration>
  <version>2.8.0</version>
  <connectionInfo>
    <searchBase>dc=rhc-ose,dc=labs,dc=redhat,dc=com</searchBase>
    <systemUsername>uid=ldap,cn=users,cn=compat,dc=rhc-ose,dc=labs,dc=redhat,dc=com</systemUsername>
    <systemPassword>OMITTED</systemPassword>
    <authScheme>simple</authScheme>
    <protocol>ldaps</protocol>
    <host>ipa.rhc-ose.labs.redhat.com</host>
    <port>636</port>
  </connectionInfo>
  <userAndGroupConfig>
    <emailAddressAttribute>mail</emailAddressAttribute>
    <ldapGroupsAsRoles>true</ldapGroupsAsRoles>
    <groupBaseDn>ou=groups</groupBaseDn>
    <groupIdAttribute>cn</groupIdAttribute>
    <groupMemberAttribute>uniqueMember</groupMemberAttribute>
    <groupMemberFormat>${username}</groupMemberFormat>
    <groupObjectClass>groupOfUniqueNames</groupObjectClass>
    <userIdAttribute>uid</userIdAttribute>
    <userObjectClass>inetOrgPerson</userObjectClass>
    <userBaseDn>cn=users,cn=accounts</userBaseDn>
    <userRealNameAttribute>displayName</userRealNameAttribute>
    <userMemberOfAttribute>memberOf</userMemberOfAttribute>
  </userAndGroupConfig>
</ldapConfiguration>
```

Create a Nexus security capabilities configuration file (`/root/repository/rhc-ose-env-configs/openshift_environments/cicd.rhc-ose.labs.redhat.com/files/nexus-security-configuration.xml`)

```
<?xml version="1.0"?>
<security-configuration>
  <version>2.0.8</version>
  <anonymousAccessEnabled>true</anonymousAccessEnabled>
  <anonymousUsername>anonymous</anonymousUsername>
  <anonymousPassword>{PkHuCWyS17QHLA7fAuA1ZXO2qooUfUFGNAAu1kOI6uc=}</anonymousPassword>
  <realms>
    <realm>XmlAuthenticatingRealm</realm>
    <realm>XmlAuthorizingRealm</realm>
    <realm>LdapAuthenticatingRealm</realm>
  </realms>
  <hashIterations>1024</hashIterations>
</security-configuration>
```

Create a Nexus security configuration file to handle role mapping (`/root/repository/rhc-ose-env-configs/openshift_environments/cicd.rhc-ose.labs.redhat.com/files/nexus-security-configuration.xml`)

```
<?xml version="1.0" encoding="UTF-8"?>
<security>
  <version>2.0.5</version>
  <users>
    <user>
      <id>deployment</id>
      <firstName>Deployment</firstName>
      <lastName>User</lastName>
      <password>b2a0e378437817cebdf753d7dff3dd75483af9e0</password>
      <status>active</status>
      <email>changeme1@yourcompany.com</email>
    </user>
    <user>
      <id>admin</id>
      <firstName>Administrator</firstName>
      <lastName>User</lastName>
      <password>$shiro1$SHA-512$1024$9AeM8XSUnzf5U8BdC/+2Xw==$is4bUGiJDWJLdgr3NF4yVcMwO2E5Dc1kzCqXvxQ3S0o9HLJUSIWYxjC25rNkfR5djsCMHWElriKspQ/x59rcOA==</password>
      <status>active</status>
      <email>changeme@yourcompany.com</email>
    </user>
    <user>
      <id>anonymous</id>
      <firstName>Nexus</firstName>
      <lastName>Anonymous User</lastName>
      <password>$shiro1$SHA-512$1024$iBJaOx1LJfxiUaHba/9Kag==$gdOdYPu41EdYAya6B7iAebxgbW24EMMbxpJ79BPmf5rNTpnpG67rfbadsrPQWN2zQESBzml6KL3kM+45Ii2kjw==</password>
      <status>active</status>
      <email>changeme2@yourcompany.com</email>
    </user>
  </users>
  <roles>
    <role>
      <id>ci_admins</id>
      <name>ci_admins</name>
      <description>External mapping for ci_admins (LDAP)</description>
      <roles>
        <role>nx-admin</role>
      </roles>
    </role>
  </roles>
  <userRoleMappings>
    <userRoleMapping>
      <userId>deployment</userId>
      <source>default</source>
      <roles>
        <role>nx-deployment</role>
        <role>repository-any-full</role>
      </roles>
    </userRoleMapping>
    <userRoleMapping>
      <userId>admin</userId>
      <source>default</source>
      <roles>
        <role>nx-admin</role>
      </roles>
    </userRoleMapping>
    <userRoleMapping>
      <userId>anonymous</userId>
      <source>default</source>
      <roles>
        <role>repository-any-read</role>
        <role>anonymous</role>
      </roles>
    </userRoleMapping>
  </userRoleMappings>
</security>
```

Copy your LDAP ca crt to `/root/repository/rhc-ose-env-configs/openshift_environments/cicd.rhc-ose.labs.redhat.com/files/ipa-ca.crt` so it can be added to the Java JDK

Create a CICD environment configuration file (`/root/repository/rhc-ose-env-configs/openshift_environments/cicd.rhc-ose.labs.redhat.com/cicd.rhc-ose.labs.redhat.com.cfg`)

```
## Platform Configs
CONF_ENV_ID=cicd.rhc-ose.labs.redhat.com # Default: random 8 character string
CONF_OPENSHIFT_VERSION=3.1
CONF_IMAGE_NAME=ose3_1-base # Default: ose3-base
CONF_SECURITY_GROUP_CICD=CI-CD
CONF_OS_FLAVOR=m1.large
CONF_STORAGE_SIZE_LOGGING="5"
CONF_PROVISION_COMPONENTS=cicd
#CONF_LOGFILE=~/openstack_provision.log # Default: ~/openstack_provision.log
## OpenShift Configs
CONF_OPENSHIFT_BASE_DOMAIN=cicd.rhc-ose.labs.redhat.com # Default: ose.example.com
CONF_JENKINS_AUTHZ=/root/repository/rhc-ose-env-configs/openshift_environments/cicd.rhc-ose.labs.redhat.com/files/jenkins-ldap-authz.xml
CONF_CICD_NEXUS_CONFIG_FILES=/root/repository/rhc-ose-env-configs/openshift_environments/cicd.rhc-ose.labs.redhat.com/files/nexus-ldap.xml:/root/repository/ldap.xml,/root/repository/rhc-ose-env-configs/openshift_environments/cicd.rhc-ose.labs.redhat.com/files/nexus-security.xml:/root/repository/security.xml,/root/repository/rhc-ose-env-configs/openshift_environments/cicd.rhc-ose.labs.redhat.com/files/nexus-security-configuration.xml:/root/repository/security-configuration.xml
CONF_JAVA_CERTS=/root/repository/rhc-ose-env-configs/openshift_environments/cicd.rhc-ose.labs.redhat.com/files/ipa-ca.crt:/root/repository/ipa-ca.crt
```

```
./osc-provision --config=/root/repository/rhc-ose-env-configs/openshift_environments/cicd.rhc-ose.labs.redhat.com/cicd.rhc-ose.labs.redhat.com.cfg --key=<key_name> --ose-version=3.1
```

You should be able to login to Nexus and Jenkins using your LDAP credentials
#### Is there a relevant Issue open for this?

None
#### Who would you like to review this?

/cc @etsauer @oybed 
