### PR TITLE
Added which package to yum installation for jekyll build

### DIFF
--- a/docker/jekyll-asciidoc-docker/Dockerfile
+++ b/docker/jekyll-asciidoc-docker/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Andrew Block “andrew.block@redhat.com”
 
 # Update System and install clients
 RUN yum update -y; \
-	yum install -y epel-release git tar java-1.8.0-openjdk libyaml-devel openssh-server autoconf gcc-c++ readline-devel zlib-devel libffi-devel openssl-devel automake libtool bison sqlite-devel; \
+	yum install -y epel-release which git tar java-1.8.0-openjdk libyaml-devel openssh-server autoconf gcc-c++ readline-devel zlib-devel libffi-devel openssl-devel automake libtool bison sqlite-devel; \
 	yum install -y nodejs; \
  	yum clean all; \
 	useradd builder; \


### PR DESCRIPTION
#### What does this PR do?

rvm requires which package to be present during jeykll build. This PR adds this to the list of installed packages
#### How should this be manually tested?

Make sure to have a version of the [OpenShift Playbooks](https://github.com/rhtconsulting/openshift-playbooks) available locally

Navigate to `docker/jekyll-asciidoc-docker` folder and run the following

```
/run.sh --directory=<path_to_playbooks>
```

The container should build successfully and the playbook content can be viewed in a web browser at `http://<docker_ip>:4000>`
#### Is there a relevant Issue open for this?

None
#### Who would you like to review this?

/cc @etsauer 
