### PR TITLE
Set HTTPS scheme in livenessProbe for secured registry

### DIFF
--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -296,6 +296,9 @@ do_create_registry() {
 
   oc env deploymentConfig/$dc_name REGISTRY_HTTP_TLS_CERTIFICATE=/etc/secrets/registry.crt REGISTRY_HTTP_TLS_KEY=/etc/secrets/registry.key
 
+  # Fix secured registry in OSE 3.1.1 (https://bugzilla.redhat.com/show_bug.cgi?id=1302956)
+  oc get dc $service_name -o yaml | sed -e 's/scheme: HTTP/scheme: HTTPS/g' | oc replace -f -
+
   # Trust certs from all nodes
   certs_dirs="/etc/docker/certs.d/$service_ip:5000 /etc/docker/certs.d/docker-registry.default.svc.cluster.local:5000"
   for node in ${NODE_HOSTNAMES//,/ }; do


### PR DESCRIPTION
#### What does this PR do?

Updates the deploymentConfig of the Integrated Docker registry to set the scheme in the livenessProbe to HTTPS
#### How should this be manually tested?

Provision a new environment and validate the docker registry pod has started successfully and is not restarting (4th column is 0)

```
oc get pods -n default | awk '/registry/'
```
#### Is there a relevant Issue open for this?

N/A
#### Who would you like to review this?

/cc @etsauer @oybed 
