### PR TITLE
Updating tools to use a separate Utility Host for install

### DIFF
--- a/provisioning/lib/helpers
+++ b/provisioning/lib/helpers
@@ -292,3 +292,11 @@ sync_files() {
   done
 }
 
+# Usage: contains "term" "string"
+# Returns 0 if term found, 1 otherwise
+contains() {
+  local e
+  for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done
+  return 1
+}
+

--- a/provisioning/osc-dns-config
+++ b/provisioning/osc-dns-config
@@ -36,6 +36,7 @@
 SCRIPT_BASE_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 VAR_NAMED_STATIC_DIR="/var/named/static"
 DEFAULT_WILDCARD_PREFIX="apps"
+DEFAULT_SUBNET_SIZE=24
 
 
 #
@@ -47,6 +48,7 @@ declare -a A_ACLlist
 # Source common features
 #
 source ${SCRIPT_BASE_DIR}/lib/constants
+source ${SCRIPT_BASE_DIR}/lib/helpers
 
 #
 # FUNCTIONS
@@ -88,6 +90,8 @@ function installDNSserver()
 {
   dns_host=${1}
 
+  echo "DNS : Installing DNS server (bind/named)..."
+
   ${SSH_CMD} root@${dns_host} 'yum -y install bind bind-utils'
 
   [ $? -ne 0 ] && echo "Failed to install DNS server on ${dns_host}" && exit 1
@@ -106,6 +110,8 @@ function prepDNSserver()
 {
   dns_host=${1}
   dns_domain=${2}
+
+  echo "DNS : Preparing DNS server ..."
 
   ${SSH_CMD} root@${dns_host} "rm -rf ${VAR_NAMED_STATIC_DIR}/*"
 
@@ -136,6 +142,8 @@ function prepDNSserver()
 function setIPtables()
 {
   dns_host=${1}
+
+  echo "DNS : Setting firewall (iptables) ... "
 
   udp='\-A INPUT \-p udp \-m state \-\-state NEW \-m udp \-\-dport 53 \-j ACCEPT'
   tcp='\-A INPUT \-p tcp \-m state \-\-state NEW \-m tcp \-\-dport 53 \-j ACCEPT'
@@ -179,6 +187,8 @@ function setDNSservers()
   search_domain=${2}
   nameserver=${3} 
 
+  echo "DNS : Updating resolv.conf for ${host} ..."
+
   ${SSH_CMD} root@${host} "
   sed -i 's/^PEERDNS=.*/PEERDNS=\"no\"/' /etc/sysconfig/network-scripts/ifcfg-*
   sed -i 's/^\(nameserver.*\)/# \1/g' /etc/resolv.conf
@@ -203,6 +213,8 @@ function setHostname()
 {
   dns_host=${1}
   hname=${2}
+
+  echo "DNS : Setting hostname for ${dns_host} ..."
 
   ${SSH_CMD} root@${dns_host} "
   if [ -e \"/etc/cloud/cloud.cfg\" ]
@@ -333,6 +345,8 @@ function setACLlist()
   dns_host=${1}
   acl_list=${2}
 
+  echo "DNS : Setting ACL list ..."
+
   ${SSH_CMD} root@${dns_host} "
   sed -i \"s/\t# ACL_PRIVATE_IP_ADDRESSES/${acl_list}/g\" /etc/named.conf
 "
@@ -351,6 +365,8 @@ function setACLlist()
 function restartDNSserver()
 {
   dns_host=${1}
+
+  echo "DNS : Applying DNS server configuration (restart) ..."
 
   ${SSH_CMD} root@${dns_host} 'systemctl restart named && systemctl enable named'
 
@@ -471,6 +487,8 @@ do
     exit 1
   fi
 
+  echo "DNS : Setting config for node - ${privateip} ..."
+
   setHostname ${privateip} node${i}.${BASE_DOMAIN}
   sleep 1
   setDNSservers ${privateip} ${BASE_DOMAIN} ${dh_private_ip}
@@ -480,7 +498,8 @@ do
   createDNSrecord ${dh_private_ip} ${privateip} ${publicip} "node${i}" "A"
   createDNSrecord ${dh_private_ip} ${privateip} ${publicip} "node${i}.${BASE_DOMAIN}" "PTR"
 
-  A_ACLlist+=(${privateip})
+  subnet=`ipcalc -n "${privateip}/${DEFAULT_SUBNET_SIZE}" | sed -ne 's/NETWORK=\(.*\)/\1/p'`
+  contains "${subnet}" "${A_ACLlist[@]}" || A_ACLlist+=(${subnet})
 
   i=$((i+1))
 done
@@ -501,6 +520,8 @@ do
     exit 1
   fi
 
+  echo "DNS : Setting config for master - ${privateip}|${publicip} ..."
+
   prepPTRConfig ${dh_private_ip} ${privateip} ${BASE_DOMAIN} PRIVATE
   prepPTRConfig ${dh_private_ip} ${publicip} ${BASE_DOMAIN} PUBLIC
 
@@ -511,15 +532,19 @@ do
   sleep 1
   setDNSservers ${privateip} ${BASE_DOMAIN} ${dh_private_ip}
 
-  A_ACLlist+=(${privateip})
+  subnet=`ipcalc -n "${privateip}/${DEFAULT_SUBNET_SIZE}" | sed -ne 's/NETWORK=\(.*\)/\1/p'`
+  contains "${subnet}" "${A_ACLlist[@]}" || A_ACLlist+=(${subnet})
 
   i=$((i+1))
 done
 
+# Ensure *this* server also has the correct DNS settings
+setDNSservers '127.0.0.1' ${BASE_DOMAIN} ${dh_private_ip}
+
 fullacllist=
 for a in "${A_ACLlist[@]}"
 do
-  fullacllist="${fullacllist}\\t${a}\/32;\\n"
+  fullacllist="${fullacllist}\\t${a}\/${DEFAULT_SUBNET_SIZE};\\n"
 done
 
 # Finally, set the ACP list

--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -
 
 SCRIPT_BASE_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
@@ -9,14 +9,6 @@ source ${SCRIPT_BASE_DIR}/lib/constants
 # Show script usage
 usage() {
   echo "Usage: $0 -m=|--master=\"<master1 private ip|master1 public ip>\" -n=|--nodes=\"<node1 private ip|node1 public ip>,...,<nodeN private ip|nodeN public ip>\" -a|--actions=\"action1,action2,...actionN\""
-}
-
-# Usage: contains "term" "string"
-# Returns 0 if term found, 1 otherwise
-contains() {
-  local e
-  for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done
-  return 1
 }
 
 # Determine whether master is a node, and if not, make node1 the 'infra' node
@@ -101,16 +93,18 @@ EOF
 }
 
 setup_authentication() {
-  users=$OPENSHIFT_USERS
+  ${SSH_CMD} root@${MASTER_HOSTNAME} "
+    users=\"${OPENSHIFT_USERS}\"
 
-  # Set up authentication
-  yum -y install httpd-tools &>/dev/null || error_out "Failed to install httpd-tools"
-  touch ${openshift_install_dir}/openshift-passwd
-  for user in $users; do
-    htpasswd -b ${openshift_install_dir}/openshift-passwd ${user%:*} ${user#*:}
-  done
+    # Set up authentication
+    yum -y install httpd-tools &>/dev/null || error_out \"Failed to install httpd-tools\"
+    touch ${openshift_install_dir}/openshift-passwd
+    for user in \$users; do
+      htpasswd -b ${openshift_install_dir}/openshift-passwd \${user%:*} \${user#*:}
+    done
 
-  systemctl restart ${openshift_master_service}
+    systemctl restart ${openshift_master_service}
+"
 }
 
 setup_cleanup_job() {
@@ -204,29 +198,7 @@ do_post(){
   echo "Post Install"
   setup_authentication
 
-  # Create router infrastructure
-  CA="${openshift_install_dir}/${openshift_master_dir}"
-
-  oadm ca create-server-cert --signer-cert=$CA/ca.crt \
-  --signer-key=$CA/ca.key --signer-serial=$CA/ca.serial.txt \
-  --hostnames="*.${OPENSHIFT_CLOUDAPPS_SUBDOMAIN}.${OPENSHIFT_BASE_DOMAIN}" \
-  --cert=$CA/cloudapps.crt --key=$CA/cloudapps.key
-
-
-  cat $CA/cloudapps.crt $CA/cloudapps.key $CA/ca.crt > $CA/cloudapps.router.pem
-
-  echo '{"kind":"ServiceAccount","apiVersion":"v1","metadata":{"name":"router"}}' | oc create -f -
-  oc get scc privileged -o yaml > priv.yaml
-  if [ $(grep -c 'system:serviceaccount:default:router' priv.yaml) -eq 0 ]; then
-    echo '- system:serviceaccount:default:router' >> priv.yaml
-    oc replace scc privileged -f priv.yaml
-  fi
-
-  oadm router router-default --default-cert=$CA/cloudapps.router.pem \
-  --credentials="${openshift_install_dir}/${openshift_master_dir}/openshift-router.kubeconfig" \
-  --selector='region=infra' \
-  --images='registry.access.redhat.com/openshift3/ose-${component}:${version}' \
-  --service-account=router
+  do_create_router
 
   do_create_registry
 
@@ -240,78 +212,119 @@ do_post(){
     $SSH_CMD $node 'sed -i "s/--insecure-registry=172.30.0.0\/16//" /etc/sysconfig/docker && systemctl restart docker'
   done
 
-  # Re-load previous ImageStream definitions ... 
-  oc delete imagestreams --all -n openshift
-  oc create -n openshift -f ${SCRIPT_BASE_DIR}/templates/image-streams-rhel7-ose3_0_2.json
-  oc create -n openshift -f /usr/share/openshift/examples/xpaas-streams/jboss-image-streams.json
-
   ### Workarounds for current issues - END
   ###########################################
+}
+
+# Create router infrastructure
+do_create_router() {
+  CA="${openshift_install_dir}/${openshift_master_dir}"
+
+  ${SSH_CMD} root@${MASTER_HOSTNAME} "
+    # First, a bit of cleanup so we can re-run and update things
+    for resource in service deploymentConfig pod route serviceaccount; do
+      resource_names=\$(oc get \$resource | awk '/router/ {print \$1}')
+      for name in \${resource_names/\'\\n\'/ }; do
+        oc delete \$resource \$name
+      done
+    done
+
+    oadm ca create-server-cert \
+      --signer-cert=$CA/ca.crt \
+      --signer-key=$CA/ca.key \
+      --signer-serial=$CA/ca.serial.txt \
+      --hostnames=\"*.${OPENSHIFT_CLOUDAPPS_SUBDOMAIN}.${OPENSHIFT_BASE_DOMAIN}\" \
+      --cert=$CA/cloudapps.crt \
+      --key=$CA/cloudapps.key
+
+    cat $CA/cloudapps.crt $CA/cloudapps.key $CA/ca.crt > $CA/cloudapps.router.pem
+
+    echo '{\"kind\":\"ServiceAccount\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"router\"}}' | oc create -f -
+    oc get scc privileged -o yaml > priv.yaml
+    if [ \$(grep -c \'system:serviceaccount:default:router\' priv.yaml) -eq 0 ]; then
+      echo '- system:serviceaccount:default:router' >> priv.yaml
+      oc replace scc privileged -f priv.yaml
+    fi
+
+    oadm router router-default \
+      --default-cert=$CA/cloudapps.router.pem \
+      --credentials=\"${openshift_install_dir}/${openshift_master_dir}/openshift-router.kubeconfig\" \
+      --selector='region=infra' \
+      --images='registry.access.redhat.com/openshift3/ose-\${component}:\${version}' \
+      --service-account=router
+"
 }
 
 do_create_registry() {
   CA="${openshift_install_dir}/${openshift_master_dir}"
 
-  # First, a bit of cleanup so we can re-run and update things
-  for resource in service deploymentConfig pod route serviceaccount secret; do
-    resource_names=$(oc get $resource | awk '/registry/ {print $1}')
-    for name in ${resource_names/'\n'/ }; do
-      oc delete $resource $name
+  ${SSH_CMD} root@${MASTER_HOSTNAME} "
+    # First, a bit of cleanup so we can re-run and update things
+    for resource in service deploymentConfig pod route serviceaccount secret; do
+      resource_names=\$(oc get \$resource | awk '/registry/ {print \$1}')
+      for name in \${resource_names/\'\\n\'/ }; do
+        oc delete \$resource \$name
+      done
     done
-  done
 
-  # Create registry
-  mkdir -p /mnt/registry
+    # Create registry
+    mkdir -p /mnt/registry
 
-  echo '{"kind":"ServiceAccount","apiVersion":"v1","metadata":{"name":"registry"}}' | oc create -f -
-  oc get scc privileged -o yaml > priv.yaml
-  if [ $(grep -c 'system:serviceaccount:default:registry' priv.yaml) -eq 0 ]; then
-    echo '- system:serviceaccount:default:registry' >> priv.yaml
-    oc replace scc privileged -f priv.yaml
-  fi
+    echo '{\"kind\":\"ServiceAccount\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"registry\"}}' | oc create -f -
+    oc get scc privileged -o yaml > priv.yaml
+    if [ \$(grep -c \'system:serviceaccount:default:registry\' priv.yaml) -eq 0 ]; then
+      echo '- system:serviceaccount:default:registry' >> priv.yaml
+      oc replace scc privileged -f priv.yaml
+    fi
 
-  created_resources=$(oadm registry --service-account=registry \
-  --config="${openshift_install_dir}/${openshift_master_dir}/admin.kubeconfig" \
-  --credentials="${openshift_install_dir}/${openshift_master_dir}/openshift-registry.kubeconfig" \
-  --images='registry.access.redhat.com/openshift3/ose-${component}:${version}' \
-  --selector='region=infra' \
-  --mount-host=/mnt/registry)
+    created_resources=\$(oadm registry --service-account=registry \
+      --config=\"${openshift_install_dir}/${openshift_master_dir}/admin.kubeconfig\" \
+      --credentials=\"${openshift_install_dir}/${openshift_master_dir}/openshift-registry.kubeconfig\" \
+      --images='registry.access.redhat.com/openshift3/ose-\${component}:\${version}' \
+      --selector='region=infra' \
+      --mount-host=/mnt/registry)
 
-  service_name=$(oc get service | awk '/registry/ {print $1}')
-  service_ip=$(oc get service $service_name | awk '/registry/ {print $2}')
-  dc_name=$(oc get deploymentconfig | awk '/registry/ {print $1}')
+    service_name=\$(oc get service | awk '/registry/ {print \$1}')
+    service_ip=\$(oc get service \$service_name | awk '/registry/ {print \$2}')
+    dc_name=\$(oc get deploymentconfig | awk '/registry/ {print \$1}')
 
-  # Secure the Registry
-  oadm ca create-server-cert --signer-cert=$CA/ca.crt \
-    --signer-key=$CA/ca.key \
-    --signer-serial=$CA/ca.serial.txt  \
-    --hostnames="registry.${OPENSHIFT_CLOUDAPPS_SUBDOMAIN}.${OPENSHIFT_BASE_DOMAIN},docker-registry.default.svc.cluster.local,${service_ip}"\
-    --cert=$CA/registry.crt --key=$CA/registry.key
+    # Secure the Registry
+    oadm ca create-server-cert --signer-cert=$CA/ca.crt \
+      --signer-key=$CA/ca.key \
+      --signer-serial=$CA/ca.serial.txt  \
+      --hostnames=\"registry.${OPENSHIFT_CLOUDAPPS_SUBDOMAIN}.${OPENSHIFT_BASE_DOMAIN},docker-registry.default.svc.cluster.local,\${service_ip}\" \
+      --cert=$CA/registry.crt \
+      --key=$CA/registry.key
 
-  oc secrets new registry-secret $CA/registry.crt $CA/registry.key
+    oc secrets new registry-secret $CA/registry.crt $CA/registry.key
 
-  oc secrets add serviceaccounts/registry secrets/registry-secret
+    oc secrets add serviceaccounts/registry secrets/registry-secret
 
-  oc volume deploymentConfig/$dc_name --add --type=secret --secret-name=registry-secret -m /etc/secrets
+    oc volume deploymentConfig/\$dc_name --add --type=secret --secret-name=registry-secret -m /etc/secrets
 
-  oc env deploymentConfig/$dc_name REGISTRY_HTTP_TLS_CERTIFICATE=/etc/secrets/registry.crt REGISTRY_HTTP_TLS_KEY=/etc/secrets/registry.key
-
-  # Trust certs from all nodes
-  certs_dirs="/etc/docker/certs.d/$service_ip:5000 /etc/docker/certs.d/docker-registry.default.svc.cluster.local:5000"
-  for node in ${NODE_HOSTNAMES//,/ }; do
-    for dir in $certs_dirs; do
-      $SSH_CMD $node "mkdir -p $dir"
-      $SCP_CMD $CA/ca.crt $node:$dir
-    done
-    $SSH_CMD $node "systemctl daemon-reload && systemctl restart docker && systemctl restart ${openshift_node_service}"
-  done
+    oc env deploymentConfig/\$dc_name REGISTRY_HTTP_TLS_CERTIFICATE=/etc/secrets/registry.crt REGISTRY_HTTP_TLS_KEY=/etc/secrets/registry.key
+"
 
   # Create Route for External Access
+  service_name=$($SSH_CMD root@${MASTER_HOSTNAME} "oc get service | awk '/registry/ {print \$1}'")
   SERVICE_NAME=$service_name
   HOSTNAME=registry.${OPENSHIFT_CLOUDAPPS_SUBDOMAIN}.${OPENSHIFT_BASE_DOMAIN}
   route_resource=$(process_template ${SCRIPT_BASE_DIR}/templates/registry-route.json SERVICE_NAME HOSTNAME )
 
-  echo "$route_resource" | oc create -f -
+  echo "${route_resource}" | $SSH_CMD root@${MASTER_HOSTNAME} "oc create -f -"
+
+  # Trust certs from all nodes - first obtain some info from the master, then copy the certs to the nodes
+  service_ip=$($SSH_CMD root@${MASTER_HOSTNAME} "oc get service ${service_name} | awk '/registry/ {print \$2}'")
+  ca_cert=$($SSH_CMD root@${MASTER_HOSTNAME} "cat $CA/ca.crt")
+
+  certs_dirs="/etc/docker/certs.d/${service_ip}:5000 /etc/docker/certs.d/docker-registry.default.svc.cluster.local:5000"
+  for node in ${NODE_HOSTNAMES//,/ }; do
+    for dir in $certs_dirs; do
+      $SSH_CMD $node "mkdir -p $dir"
+      echo "${ca_cert}" | $SSH_CMD root@${node} "cat >> $dir/ca.crt"
+    done
+    $SSH_CMD $node "systemctl daemon-reload && systemctl restart docker && systemctl restart ${openshift_node_service}"
+  done
 }
 
 # Process input

--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -212,6 +212,9 @@ do_post(){
     $SSH_CMD $node 'sed -i "s/--insecure-registry=172.30.0.0\/16//" /etc/sysconfig/docker && systemctl restart docker'
   done
 
+  # Temporary workaround for an OSE v3.1.1 issue with the registry storage permissions
+  ${SSH_CMD} root@${MASTER_HOSTNAME} "chmod 0777 /mnt/registry"
+
   ### Workarounds for current issues - END
   ###########################################
 }
@@ -304,8 +307,8 @@ do_create_registry() {
 
     oc env deploymentConfig/\$dc_name REGISTRY_HTTP_TLS_CERTIFICATE=/etc/secrets/registry.crt REGISTRY_HTTP_TLS_KEY=/etc/secrets/registry.key
 
-  # Fix secured registry in OSE 3.1.1 (https://bugzilla.redhat.com/show_bug.cgi?id=1302956)
-  oc get dc $service_name -o yaml | sed -e 's/scheme: HTTP/scheme: HTTPS/g' | oc replace -f -
+    # Fix secured registry in OSE 3.1.1 (https://bugzilla.redhat.com/show_bug.cgi?id=1302956)
+    oc get dc \$service_name -o yaml | sed -e 's/scheme: HTTP/scheme: HTTPS/g' | oc replace -f -
 "
 
   # Create Route for External Access

--- a/provisioning/osc-provision
+++ b/provisioning/osc-provision
@@ -66,6 +66,14 @@ do_delete() {
   $command || error_out "Delete failed. See log at ${LOGFILE}." ${ERROR_CODE_PROVISION_FAILURE}
 }
 
+do_delete_by_ip() {
+  command="${SCRIPT_BASE_DIR}/${platform}/provision.sh
+  --action delete_by_ip
+  --ips ${1}
+  --n"
+  $command || error_out "Delete (by-ip) failed. See log at ${LOGFILE}." ${ERROR_CODE_PROVISION_FAILURE}
+}
+
 install_cicd() {
   # Clean out previous install attempts
   ${SSH_CMD} root@${cicd_public} "rm -rf ~/${REPO_BASE_NAME}"
@@ -91,22 +99,22 @@ install_cicd() {
 
 install_openshift() {
   # Clean out previous install attempts
-  ${SSH_CMD} root@${master_public} "rm -rf ~/${REPO_BASE_NAME}"
+  ${SSH_CMD} root@${utility_public} "rm -rf ~/${REPO_BASE_NAME}"
   # Script is executed from ${REPO_BASE_NAME}/provisioning, so we need to strip two directories
   pushd $(dirname $(dirname ${SCRIPT_BASE_DIR})) >/dev/null
     # Pull Repo into master so we can continue installation
-    tar cf - ${REPO_BASE_NAME} | ${SSH_CMD} root@${master_public} tar xf -
+    tar cf - ${REPO_BASE_NAME} | ${SSH_CMD} root@${utility_public} tar xf -
   popd >/dev/null
 
   # Make sure correct version of the ansible hosts file is used
-  ${SSH_CMD} root@${master_public} "cp -f ~/${REPO_BASE_NAME}/provisioning/templates/${ANSIBLE_HOSTS_FILE} ~/${REPO_BASE_NAME}/provisioning/templates/ansible-hosts"
-  ${SSH_CMD} root@${master_public} "awk -F'=' '/${ANSIBLE_PLAYBOOK}/ {print \"ansible_playbook=\"\$2}' ~/${REPO_BASE_NAME}/provisioning/lib/constants >> ~/${REPO_BASE_NAME}/provisioning/lib/constants"
-  ${SSH_CMD} root@${master_public} "awk -F'=' '/${OPENSHIFT_INSTALL_DIR}/ {print \"openshift_install_dir=\"\$2}' ~/${REPO_BASE_NAME}/provisioning/lib/constants >> ~/${REPO_BASE_NAME}/provisioning/lib/constants"
-  ${SSH_CMD} root@${master_public} "awk -F'=' '/${OPENSHIFT_MASTER_SERVICE}/ {print \"openshift_master_service=\"\$2}' ~/${REPO_BASE_NAME}/provisioning/lib/constants >> ~/${REPO_BASE_NAME}/provisioning/lib/constants"
-  ${SSH_CMD} root@${master_public} "awk -F'=' '/${OPENSHIFT_NODE_SERVICE}/ {print \"openshift_node_service=\"\$2}' ~/${REPO_BASE_NAME}/provisioning/lib/constants >> ~/${REPO_BASE_NAME}/provisioning/lib/constants"
-  ${SSH_CMD} root@${master_public} "awk -F'=' '/${OPENSHIFT_IDENTITY_PROVIDER}/ {print \"openshift_identity_provider_json=\"\$2}' ~/${REPO_BASE_NAME}/provisioning/lib/constants >> ~/${REPO_BASE_NAME}/provisioning/lib/constants"
+  ${SSH_CMD} root@${utility_public} "cp -f ~/${REPO_BASE_NAME}/provisioning/templates/${ANSIBLE_HOSTS_FILE} ~/${REPO_BASE_NAME}/provisioning/templates/ansible-hosts"
+  ${SSH_CMD} root@${utility_public} "awk -F'=' '/${ANSIBLE_PLAYBOOK}/ {print \"ansible_playbook=\"\$2}' ~/${REPO_BASE_NAME}/provisioning/lib/constants >> ~/${REPO_BASE_NAME}/provisioning/lib/constants"
+  ${SSH_CMD} root@${utility_public} "awk -F'=' '/${OPENSHIFT_INSTALL_DIR}/ {print \"openshift_install_dir=\"\$2}' ~/${REPO_BASE_NAME}/provisioning/lib/constants >> ~/${REPO_BASE_NAME}/provisioning/lib/constants"
+  ${SSH_CMD} root@${utility_public} "awk -F'=' '/${OPENSHIFT_MASTER_SERVICE}/ {print \"openshift_master_service=\"\$2}' ~/${REPO_BASE_NAME}/provisioning/lib/constants >> ~/${REPO_BASE_NAME}/provisioning/lib/constants"
+  ${SSH_CMD} root@${utility_public} "awk -F'=' '/${OPENSHIFT_NODE_SERVICE}/ {print \"openshift_node_service=\"\$2}' ~/${REPO_BASE_NAME}/provisioning/lib/constants >> ~/${REPO_BASE_NAME}/provisioning/lib/constants"
+  ${SSH_CMD} root@${utility_public} "awk -F'=' '/${OPENSHIFT_IDENTITY_PROVIDER}/ {print \"openshift_identity_provider_json=\"\$2}' ~/${REPO_BASE_NAME}/provisioning/lib/constants >> ~/${REPO_BASE_NAME}/provisioning/lib/constants"
 
-  ${SSH_CMD} root@${master_public} "$CONF_ENVIRONMENT bash${bash_opts} ~/${REPO_BASE_NAME}/provisioning/osc-install -m='${master_ip}' -n='${node_ips//$'\n'/,}' -a='prep,dns,install,post'"
+  ${SSH_CMD} root@${utility_public} "$CONF_ENVIRONMENT bash${bash_opts} ~/${REPO_BASE_NAME}/provisioning/osc-install -m='${master_ip}' -n='${node_ips//$'\n'/,}' -a='prep,dns,install,post'"
 }
 
 random_string() {
@@ -139,6 +147,9 @@ provision_openshift() {
   fi
 
   # Provision instances
+  echo "Provisioning Utility Host. This could take several minutes."
+  utility_ip=$(provision_utility_host) || error_out "Provisioning Failed." $ERROR_CODE_PROVISION_FAILURE
+  echo "Complete!"
   echo "Provisioning master. This could take several minutes."
   master_ip=$(provision_masters) || error_out "Provisioning Failed." $ERROR_CODE_PROVISION_FAILURE
   echo "Complete!"
@@ -146,11 +157,12 @@ provision_openshift() {
   node_ips=$(provision_nodes) || error_out "Provisioning Failed." $ERROR_CODE_PROVISION_FAILURE
   echo "Complete!"
 
+  utility_public=$(get_public_ips "${utility_ip}")
   master_public=$(get_public_ips "${master_ip}")
   node_publics=$(get_public_ips "${node_ips//$'\n'/,}")
 
   # Sync SSH keys
-  ${SCRIPT_BASE_DIR}/osc-sync-keys -m="${master_public}" -n="${master_public},${node_publics}"
+  ${SCRIPT_BASE_DIR}/osc-sync-keys -m="${utility_public}" -n="${master_public},${node_publics}"
   [ $? -eq 0 ] || error_out "Key Sync Failed."
 
   if $master_is_node; then
@@ -173,6 +185,10 @@ provision_openshift() {
     install_openshift
   fi
 
+  # Clean-up
+  echo "Cleaning-up provisioning environment..."
+  do_delete_by_ip ${utility_public}
+
   dns_server=${node_publics##*,}
 
   FINAL_OUTPUT="${FINAL_OUTPUT}
@@ -188,7 +204,6 @@ Nodes: "
   done
   FINAL_OUTPUT="${FINAL_OUTPUT}
 DNS Server: $(get_hostnames $dns_server $OPENSHIFT_BASE_DOMAIN $dns_server)"
-
 }
 
 provision_cicd_server() {
@@ -202,6 +217,19 @@ provision_cicd_server() {
   --n \
   --debug"
   $command || error_out "CICD Provision failed. See log at ${LOGFILE}." ${ERROR_CODE_PROVISION_FAILURE}
+}
+
+provision_utility_host() {
+  instance_name="utility-${ENV_ID}"
+  command="${SCRIPT_BASE_DIR}/${platform}/provision.sh \
+  --instance-name ${instance_name} \
+  --key ${key} \
+  --flavor ${OS_FLAVOR} \
+  --image-name ${IMAGE_NAME} \
+  --security-groups ${SECURITY_GROUP_MASTER} \
+  --n \
+  --debug"
+  $command || error_out "Utility Host Provision failed. See log at ${LOGFILE}." ${ERROR_CODE_PROVISION_FAILURE}
 }
 
 provision_masters() {

--- a/provisioning/osc-sync-keys
+++ b/provisioning/osc-sync-keys
@@ -42,7 +42,11 @@ else
   echo "Done"
 fi
 
+# Extract public key and ensure *this* host can SSH to itself
 public_key=$($SSH_CMD root@${MASTER} 'cat ~/.ssh/id_rsa.pub')
+$SSH_CMD root@${MASTER} 'mkdir -p ~/.ssh'
+echo "${public_key}" | $SSH_CMD root@${MASTER} 'cat  >> ~/.ssh/authorized_keys'
+$SSH_CMD root@${MASTER} 'chmod 700 ~/.ssh; chmod 600 ~/.ssh/*'
 
 for node in ${NODES//,/ }; do
   echo -n "Pushing key for node ${node}..."


### PR DESCRIPTION
#### What does this PR do?

Updating the tools to use a Utility Host to do the install - i.e.: no longer run the install from the master as this is causing problems with restarting firewalls, etc.
#### How should this be manually tested?

Perform an install using the "osc-provision" tool, e.g.: command:

```
./osc-provision --num-node=2 --key=<pub_SSH_key> --ose-version=3.1
```

Afterwards check that the environment is operational (registry, router, etc. have all been deployed) and that new projects and apps can be created. 
#### Is there a relevant Issue open for this?
#97
#### Who would you like to review this?

/cc @etsauer @sabre1041 
PS: @sabre1041 this may also impact the CI/CD tools - please review with that in mind.
