### PR TITLE
Added ansible support to Docker Openstack client

### DIFF
--- a/docker/openstack-docker-client/Dockerfile
+++ b/docker/openstack-docker-client/Dockerfile
@@ -7,7 +7,7 @@ ADD bin/start.sh /root/
 # Update System and install clients
 RUN yum update -y; \
     yum install -y python-devel epel-release http://rdo.fedorapeople.org/openstack-juno/rdo-release-juno.rpm; \
-	yum install -y git tar bind-utils python-pip python-ceilometerclient python-cinderclient python-glanceclient python-heatclient python-neutronclient python-novaclient python-saharaclient python-swiftclient python-troveclient python-openstackclient; \
+	yum install -y git tar bind-utils ansible python-pip python-ceilometerclient python-cinderclient python-glanceclient python-heatclient python-neutronclient python-novaclient python-saharaclient python-swiftclient python-troveclient python-openstackclient; \
  	yum clean all
 
 # Set /root as starting directory

--- a/docker/openstack-docker-client/run.sh
+++ b/docker/openstack-docker-client/run.sh
@@ -17,7 +17,7 @@ usage() {
      Usage: $0 [options]
      Options:
      --configdir=<configdir>       : Directory containing Openstack configuration files (Default: ~/.openstack/)
-     --name=<name>                 : Name of the assembled image (Default: rhtconsulting/rhc-openstack-client)
+     --image-name=<name>           : Name of the image to build or use (Default: rhtconsulting/rhc-openstack-client)
      --keep                        : Whether to keep the the container after exiting
      --ssh=<ssh>                   : Location of SSH keys to mount into the container (Default: ~/.ssh)
      --repository=<repository>     : Directory containing a repository to mount inside the container
@@ -38,7 +38,7 @@ do
 	  -k|--keep)
       REMOVE_CONTAINER_ON_EXIT=""
       shift;;
-  	-n=*|--name=*)
+  	-n=*|--image-name=*)
       OPENSTACK_CLIENT_IMAGE="${i#*=}"
       shift;;
     -s=*|--ssh=*)


### PR DESCRIPTION
#### What does this PR do?

Added Ansible support to OpenStack Docker client
#### How should this be manually tested?

Delete an existing image if already available

```
docker rmi rhtconsulting/rhc-openstack-client
```

Navigate to the _docker/openstack-docker-client_

Build Container

```
./run.sh
```

After the images builds and the container starts, verify Ansible is available

```
ansible --version
```

Verify the response 

```
ansible 1.9.4
  configured module search path = None
```
#### Is there a relevant Issue open for this?

N/A
#### Who would you like to review this?

/cc @etsauer @oybed 
