### PR TITLE
Registry Role for ansible playbooks

### DIFF
--- a/rhc-ose-ansible/registry-provision.yaml
+++ b/rhc-ose-ansible/registry-provision.yaml
@@ -1,0 +1,19 @@
+---
+- hosts: localhost
+  pre_tasks:
+  - include: roles/common/pre_tasks/pre_tasks.yml
+  roles:
+    - role: common
+    - role: openshift-common
+    # Provision Master
+    - role: openstack-create
+      type: "registry"
+      key_name: "{{ openstack_key_name }}"
+      image_name: "ose3_1-base"
+      flavor_name: "{{ openshift_openstack_flavor_name }}"
+      security_groups: "docker-registry,default"
+      register_host_group: "registry"
+      node_count: "1"
+- hosts: registry
+  roles:
+    - role: registry

--- a/rhc-ose-ansible/roles/registry/tasks/main.yaml
+++ b/rhc-ose-ansible/roles/registry/tasks/main.yaml
@@ -1,0 +1,24 @@
+---
+- name: Install Registry
+  yum:
+    name: docker-registry
+    state: latest
+- name: Enable & Start Registry
+  service:
+    name: docker-registry
+    enabled: yes
+    state: started
+- name: Install firewalld
+  yum:
+    name: firewalld
+    state: latest
+- name: Enable Firewalld
+  service:
+    name: firewalld
+    enabled: yes
+    state: started
+- name: Open Firewall for Registry
+  firewalld:
+    port: 5000/tcp
+    permanent: true
+    state: enabled

--- a/rhc-ose-ansible/roles/registry/tasks/main.yaml
+++ b/rhc-ose-ansible/roles/registry/tasks/main.yaml
@@ -1,24 +1,15 @@
 ---
 - name: Install Registry
-  yum:
-    name: docker-registry
-    state: latest
+  yum: name=docker-registry state=latest
+
 - name: Enable & Start Registry
-  service:
-    name: docker-registry
-    enabled: yes
-    state: started
+  service: name=docker-registry enabled=yes state=started
+
 - name: Install firewalld
-  yum:
-    name: firewalld
-    state: latest
+  yum: name=firewalld state=latest
+
 - name: Enable Firewalld
-  service:
-    name: firewalld
-    enabled: yes
-    state: started
+  service: name=firewalld enabled=yes state=started
+
 - name: Open Firewall for Registry
-  firewalld:
-    port: 5000/tcp
-    permanent: true
-    state: enabled
+  firewalld: port=5000/tcp permanent=yes state=enabled immediate=yes


### PR DESCRIPTION
#### What does this PR do?

Adds a playbooks for spinning up a basic docker registry
#### How should this be manually tested?

From a host/container with ansible installed:
1. Add your openstack key name to rhc-ose-ansible/inventory/ose-provision
2. Run the following:

```
cd rhc-ose-ansible
ansible-playbook -i inventory/ose-provision registry-provision.yaml
```

Then, validate you can reach the registry.

```
curl http://<host ip>:5000/
```

If you want you can push and image to it

```
docker pull busybox
docker tag <image id> <host-ip>:5000/somename/busybox
docker push <host-ip>:5000/somename/busybox
```
#### Is there a relevant Issue open for this?

n/a
#### Who would you like to review this?

/cc @sabre1041 @oybed 
