### PR TITLE
Updated permissions for registry mount in 3.1.1

### DIFF
--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -212,8 +212,8 @@ do_post(){
     $SSH_CMD $node 'sed -i "s/--insecure-registry=172.30.0.0\/16//" /etc/sysconfig/docker && systemctl restart docker'
   done
 
-  # Temporary workaround for an OSE v3.1.1 issue with the registry storage permissions
-  ${SSH_CMD} root@${MASTER_HOSTNAME} "chmod 0777 /mnt/registry"
+  # Workaround for OSE v3.1.1 issue with the registry storage permissions (https://access.redhat.com/solutions/2173071)
+  ${SSH_CMD} root@${MASTER_HOSTNAME} "chown -R 1001 /mnt/registry"
 
   ### Workarounds for current issues - END
   ###########################################


### PR DESCRIPTION
#### What does this PR do?

Updated permissions for registry mount in 3.1.1 based on solution recommendations 

https://access.redhat.com/solutions/2173071
#### How should this be manually tested?
1. Provision new OSE environment
2. Create a new project
3. Deploy **cakephp-example** instant application
4. Verify build completes and pushes successfully to integrated registry
#### Is there a relevant Issue open for this?

No
#### Who would you like to review this?

/cc @oybed @etsauer 
