### PR TITLE
Fixed incorrect reference to jekyll builder in README

### DIFF
--- a/docker/jekyll-asciidoc-docker/README.md
+++ b/docker/jekyll-asciidoc-docker/README.md
@@ -28,9 +28,9 @@ The process of creating and running the docker container is facilitated through 
 It will produce the docker image based on a *Dockerfile* and run the docker container based on the following parameters:
 
 ```
-$ ./docker/openstack-docker-client/run.sh --help
+$ ./docker/jekyll-asciidoc-docker/run.sh --help
 
-     Usage: ./docker/jekyll-asciidoc/run.sh [options]
+     Usage: ./docker/jekyll-asciidoc-docker/run.sh [options]
      Options:
      --name=<name>                 : Name of the assembled image (Default: rhtconsulting/jekyll-asciidoc)
      --keep                        : Whether to keep the the container after exiting


### PR DESCRIPTION
#### What does this PR do?

Corrects documentation issue in `jekyll-asciidoc-docker` README
#### How should this be manually tested?

N/A
#### Is there a relevant Issue open for this?
#120
#### Who would you like to review this?

/cc @etsauer @oybed @JaredBurck 
