### PR TITLE
Updated tools to do 'subscription-manager refresh' to ensure a valid sub

### DIFF
--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -159,11 +159,12 @@ validate_ssh() {
 ## Action functions
 do_prep() {
   echo "Beginning action: Prep"
+  subscription-manager refresh &>/dev/null || error_out "Failed to run 'subscription-manager refresh' during Prep phase."
   yum clean all
   yum -y update &>/dev/null || error_out "Failed to run yum update during Prep phase."
 
   for host in $(get_private_ips ${NODES} | sed 's/,/ /g'); do
-    ${SSH_CMD} root@${host} "yum clean all; yum update -y"
+    ${SSH_CMD} root@${host} "subscription-manager refresh; yum clean all; yum update -y"
   done
 }
 


### PR DESCRIPTION
#### What does this PR do?

Added 'subscription-manager refresh' to ensure that the subscription is up-to-date within the base image before attempting to do any yum commands.
#### How should this be manually tested?

Run a provisioning of a new environment - ensure no errors.
#### Is there a relevant Issue open for this?

N/A
#### Who would you like to review this?

/cc @etsauer 
