### PR TITLE
Add subscription-manager support for Hosted or Satellite

### DIFF
--- a/rhc-ose-ansible/inventory/ose-provision
+++ b/rhc-ose-ansible/inventory/ose-provision
@@ -12,27 +12,24 @@ openstack_key_name=""
 #openshift_openstack_master_storage_size: 10
 #openshift_openstack_node_storage_size: 10
 
-# Subscription Manager method. Set to 'satellite', 'hosted' or none/false/blank to disable all registration
-rhsm_method=''
-
-# Subscription Manager server hostname. If using a Satellite server, set the FQDN here. For RHSM Hosted this value is ignored.
-rhsm_server=''
+# Subscription Manager Satellite hostname. If using a Satellite server, set the FQDN here. For RHSM Hosted this value must be blank, none or false.
+rhsm_satellite=''
 
 # Subscription Manager username and password. Required for RHSM Hosted. Can be optionally used for Satellite, but it may be better to use 'rhsm_activationkey' for this
 rhsm_username=''
 rhsm_password=''
 
-# Optional Satellite Subscription Manager Organization - required for Satellite, ignored if using RHSM Hosted
+# Optional Subscription Manager Satellite Organization - required for Satellite, ignored if using RHSM Hosted
 rhsm_org=''
 
-# Optional Satellite Subscription Manager Activation Key, use this instead of 'rhsm_username' and 'rhsm_password' if using Satellite to provide repositories and authentication in one key
+# Optional Subscription Manager Satellite Activation Key, use this instead of 'rhsm_username' and 'rhsm_password' if using Satellite to provide repositories and authentication in one key
 rhsm_activationkey=''
 
 # Optional Subscription Manager pool, determine this by running 'subscription-manager list --available' on a registered system. Valid for RHSM Hosted or Satellite
 rhsm_pool=''
 
-# Optional Repositories to enable, this can also be specified in the 'rhsm_activationkey'. Valid for RHSM Hosted or Satellite
-# A better place for this is the group_vars/ so we can use proper yaml lists, but left it this way to follow the current workflow
+# Optional Repositories to enable. If left blank it is expected that the 'rhsm_activationkey' will specify repos instead.  If populated, a 'subscription-manager repos --disable=*' will be run and each of the specified repos explicitly enabled. Valid for RHSM Hosted or Satellite
+# A better place for this is the group_vars/ to use proper yaml lists, but can be specified as such in inventory:
 rhsm_repos='["rhel-7-server-rpms", "rhel-7-server-ose-3.1-rpms", "rhel-7-server-extras-rpms"]'
 
 # This is the ose3 inventory file...

--- a/rhc-ose-ansible/inventory/ose-provision
+++ b/rhc-ose-ansible/inventory/ose-provision
@@ -12,6 +12,28 @@ openstack_key_name=""
 #openshift_openstack_master_storage_size: 10
 #openshift_openstack_node_storage_size: 10
 
+# Subscription Manager method. Set to 'satellite', 'hosted' or none/false/blank to disable all registration
+rhsm_method=''
+
+# Subscription Manager server hostname. If using a Satellite server, set the FQDN here. For RHSM Hosted this value is ignored.
+rhsm_server=''
+
+# Subscription Manager username and password. Required for RHSM Hosted. Can be optionally used for Satellite, but it may be better to use 'rhsm_activationkey' for this
+rhsm_username=''
+rhsm_password=''
+
+# Optional Satellite Subscription Manager Organization - required for Satellite, ignored if using RHSM Hosted
+rhsm_org=''
+
+# Optional Satellite Subscription Manager Activation Key, use this instead of 'rhsm_username' and 'rhsm_password' if using Satellite to provide repositories and authentication in one key
+rhsm_activationkey=''
+
+# Optional Subscription Manager pool, determine this by running 'subscription-manager list --available' on a registered system. Valid for RHSM Hosted or Satellite
+rhsm_pool=''
+
+# Optional Repositories to enable, this can also be specified in the 'rhsm_activationkey'. Valid for RHSM Hosted or Satellite
+# A better place for this is the group_vars/ so we can use proper yaml lists, but left it this way to follow the current workflow
+rhsm_repos='["rhel-7-server-rpms", "rhel-7-server-ose-3.1-rpms", "rhel-7-server-extras-rpms"]'
 
 # This is the ose3 inventory file...
 [ose3]

--- a/rhc-ose-ansible/ose-provision.yml
+++ b/rhc-ose-ansible/ose-provision.yml
@@ -1,11 +1,6 @@
 ---
 # Provision OpenStack instances
 - hosts: localhost
-  vars_prompt:
-    - name: "rhsm_password"
-      prompt: "Subscription Manager password (enter blank if using rhsm_activationkey or to disable registration)"
-      confirm: yes
-      private: yes
   pre_tasks:
   - include: roles/common/pre_tasks/pre_tasks.yml
   - include: roles/subscription-manager/pre_tasks/pre_tasks.yml

--- a/rhc-ose-ansible/ose-provision.yml
+++ b/rhc-ose-ansible/ose-provision.yml
@@ -1,9 +1,14 @@
 ---
 # Provision OpenStack instances
 - hosts: localhost
+  vars_prompt:
+    - name: "rhsm_password"
+      prompt: "Subscription Manager password (enter blank if using rhsm_activationkey or to disable registration)"
+      confirm: yes
+      private: yes
   pre_tasks:
-  - include: roles/openstack-create/pre_tasks/pre_tasks.yml
   - include: roles/common/pre_tasks/pre_tasks.yml
+  - include: roles/subscription-manager/pre_tasks/pre_tasks.yml
   roles:
     - role: common
     - role: openshift-common
@@ -35,4 +40,5 @@
     - openshift_masters
     - openshift_nodes
   roles:
+    - { role: subscription-manager, when: hostvars.localhost.rhsm_register, tags: 'subscription-manager' }
     - openshift-provision

--- a/rhc-ose-ansible/ose-provision.yml
+++ b/rhc-ose-ansible/ose-provision.yml
@@ -2,6 +2,7 @@
 # Provision OpenStack instances
 - hosts: localhost
   pre_tasks:
+  - include: roles/openstack-create/pre_tasks/pre_tasks.yml
   - include: roles/common/pre_tasks/pre_tasks.yml
   - include: roles/subscription-manager/pre_tasks/pre_tasks.yml
   roles:
@@ -35,5 +36,5 @@
     - openshift_masters
     - openshift_nodes
   roles:
-    - { role: subscription-manager, when: hostvars.localhost.rhsm_register, tags: 'subscription-manager' }
+    - { role: subscription-manager, when: hostvars.localhost.rhsm_register, tags: 'subscription-manager', ansible_sudo: true }
     - openshift-provision

--- a/rhc-ose-ansible/roles/openshift-provision/tasks/main.yml
+++ b/rhc-ose-ansible/roles/openshift-provision/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
 # Starting Point for OpenShift Installation and Configuration
-- name: Cleaning yum repositories
-  command: "yum clean all"
-  
+
 - name: upgrade all packages
   yum: name=* state=latest
 

--- a/rhc-ose-ansible/roles/openshift-provision/tasks/main.yml
+++ b/rhc-ose-ansible/roles/openshift-provision/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 # Starting Point for OpenShift Installation and Configuration
-
+- name: Cleaning yum repositories
+  command: "yum clean all"
+  
 - name: upgrade all packages
   yum: name=* state=latest
-

--- a/rhc-ose-ansible/roles/subscription-manager/README.md
+++ b/rhc-ose-ansible/roles/subscription-manager/README.md
@@ -2,21 +2,11 @@
 
 ## Parameters
 
-This role depends on user specified variables. These can be set in the inventory file, group_vars or passed to the playbook from the CLI. The variables are:
+This role depends on user specified variables. These can be set in the inventory file, group_vars or passed to the playbook from the CLI. No values are set by default which disables this role. The variables are:
 
-### rhsm_method
+### rhsm_satellite
 
-Subscription Manager method to use for registration. Valid values are:
-
-* **satellite** - Use a Satellite server. Additional variables required include **rhsm_server**, **rhsm_org** and either (**rhsm_username** and **rhsm_password**) or **rhsm_activationkey**
-* **hosted** - Use Red Hat's CDN. Additional variables required are **rhsm_server** (defaults to RHSM CDN) and **rhsm_username** and **rhsm_password**
-* none/false/blank will disable any subscription manager activities (this is the default if no parameters are set)
-
-Default: none
-
-### rhsm_server
-
-Subscription Manager server hostname. If using a Satellite server set the FQDN here. If using RHSM Hosted this value is ignored.
+Subscription Manager server hostname. If using a Satellite server set the FQDN here. If using RHSM Hosted this value must be left blank, none or false.
 
 Default: none
 
@@ -34,13 +24,13 @@ Default: none
 
 ### rhsm_org
 
-Optional Satellite Subscription Manager Organization. Required for Satellite, ignored if using RHSM Hosted.
+Optional Subscription Manager Satellite Organization. Required for Satellite, ignored if using RHSM Hosted.
 
 Default: none
 
 ### rhsm_activationkey
 
-Optional Satellite Subscription Manager Activation Key, use this instead of **rhsm_username** and **rhsm_password** if using Satellite to provide repositories and authentication in a key instead.
+Optional Subscription Manager Satellite Activation Key, use this instead of **rhsm_username** and **rhsm_password** if using Satellite to provide repositories and authentication in a key instead.
 
 Default: none
 
@@ -52,7 +42,7 @@ Default: none
 
 ### rhsm_repos
 
-Optional Repositories to enable, this can also be specified in the **rhsm_activationkey**. Valid for RHSM Hosted or Satellite. Specifying **rhsm_activationkey** will ignore this option.
+Optional list of repositories to enable. If left blank it is expected that the **rhsm_activationkey** will specify repos instead.  If populated, a **subscription-manager repos --disable=\*** will be run and each of the specified repos explicitly enabled. Valid for RHSM Hosted or Satellite
 
 NOTE: If specifying this value in an inventory file as opposed to group_vars, be sure to define it as a proper list as such:
 
@@ -75,7 +65,7 @@ The bulk of the work is performed in the main.yml for this role. The pre-task pl
 
 ```
   roles:
-    - { role: subscription-manager, when: not hostvars.localhost.rhsm_skip, tags: 'subscription-manager' }
+    - { role: subscription-manager, when: hostvars.localhost.rhsm_register, tags: 'subscription-manager' }
 ```
 
 ## Running the Playbook
@@ -83,13 +73,13 @@ The bulk of the work is performed in the main.yml for this role. The pre-task pl
 To register to RHSM Hosted with username and password:
 
 ```
-ansible-playbook -i inventory/ose-provision ose-provision.yml -e "rhsm_method='hosted' rhsm_username=vvaldez rhsm_password='hunter2' openstack_key_name='vvaldez'"
+ansible-playbook -i inventory/ose-provision ose-provision.yml -e "rhsm_username=vvaldez rhsm_password=hunter2"
 ```
 
 To register to a Satellite server with an activation key:
 
 ```
-ansible-playbook -i inventory/ose-provision ose-provision.yml -e "rhsm_server='10.12.32.1' rhsm_org='cloud_practice' rhsm_activationkey='rhel-7-ose-3-1' openstack_key_name='vvaldez' rhsm_method='satellite'"
+ansible-playbook -i inventory/ose-provision ose-provision.yml -e "rhsm_satellite=satellite.example.com rhsm_org=example_org rhsm_activationkey=rhel-7-ose-3-1"
 ```
 
-To ignore any Subscription Manager activities, simple do not set any parameters or explicitly set **rhsm_method** to false.
+To ignore any Subscription Manager activities, simply do not set any parameters.

--- a/rhc-ose-ansible/roles/subscription-manager/README.md
+++ b/rhc-ose-ansible/roles/subscription-manager/README.md
@@ -18,7 +18,9 @@ Default: none
 
 ### rhsm_password
 
-Subscription Manager password. Required for RHSM Hosted. Can be optionally used for Satellite, but it may be better to use **rhsm_activationkey** for this.
+Subscription Manager password. Required for RHSM Hosted. Can be optionally used for Satellite, but it may be better to use **rhsm_activationkey** for this. 
+
+NOTE: This variable is prompted for at the start of the playbook run. This is for security purposes so the password is not left in the command history. If specified on the command-line or set in a variable file it will be ignored and the value captured from the prompt will overwrite it instead.
 
 Default: none
 
@@ -50,7 +52,25 @@ rhsm_repos='["rhel-7-server-rpms", "rhel-7-server-ose-3.1-rpms", "rhel-7-server-
 
 Default: none
 
-## Pre-tasks
+## Calling This Role
+Calling this role requires adding a **vars_prompt**, **pre_tasks**, and **roles** section of a play
+
+### vars_prompt
+Unfortunately **vars_prompt** can only be used at the play level before role tasks are executed, so this is the only place it can go. See http://stackoverflow.com/questions/25466675/ansible-to-conditionally-prompt-for-a-variable
+
+Add a prompt to capture **rhsm_password**
+
+```
+- hosts: localhost
+  vars_prompt:
+  # Unfortunately vars_prompt can only be used at the play level before role tasks, so this is the only place it can go. See http://stackoverflow.com/questions/25466675/ansible-to-conditionally-prompt-for-a-variable
+    - name: "rhsm_password"
+      prompt: "Subscription Manager password (enter blank if using rhsm_activationkey or to disable registration)"
+      confirm: yes
+      private: yes
+```
+
+### pre-tasks
 
 A number of variable checks are performed before any tasks to ensure the proper parameters are set. To include these checks call the pre_task yaml before any roles:
 
@@ -59,7 +79,7 @@ A number of variable checks are performed before any tasks to ensure the proper 
   - include: roles/subscription-manager/pre_tasks/pre_tasks.yml 
 ```
 
-## Tasks
+### roles
 
 The bulk of the work is performed in the main.yml for this role. The pre-task play will set a variable which can be checked to contitionally include this role as such:
 
@@ -73,7 +93,7 @@ The bulk of the work is performed in the main.yml for this role. The pre-task pl
 To register to RHSM Hosted with username and password:
 
 ```
-ansible-playbook -i inventory/ose-provision ose-provision.yml -e "rhsm_username=vvaldez rhsm_password=hunter2"
+ansible-playbook -i inventory/ose-provision ose-provision.yml -e "rhsm_username=vvaldez"
 ```
 
 To register to a Satellite server with an activation key:
@@ -82,4 +102,4 @@ To register to a Satellite server with an activation key:
 ansible-playbook -i inventory/ose-provision ose-provision.yml -e "rhsm_satellite=satellite.example.com rhsm_org=example_org rhsm_activationkey=rhel-7-ose-3-1"
 ```
 
-To ignore any Subscription Manager activities, simply do not set any parameters.
+To ignore any Subscription Manager activities, simply do not set any parameters. When prompted for the password, hit **Enter** to set a blank password.

--- a/rhc-ose-ansible/roles/subscription-manager/README.md
+++ b/rhc-ose-ansible/roles/subscription-manager/README.md
@@ -20,7 +20,48 @@ Default: none
 
 Subscription Manager password. Required for RHSM Hosted. Can be optionally used for Satellite, but it may be better to use **rhsm_activationkey** for this. 
 
-NOTE: This variable is prompted for at the start of the playbook run. This is for security purposes so the password is not left in the command history. If specified on the command-line or set in a variable file it will be ignored and the value captured from the prompt will overwrite it instead.
+NOTE: If this variable is specified on the command-line or set in a variable file it may leave your password exposed. For this reason you may perfer to use an Activation Key if using Satellite. For RHSM Hosted, your password must be specified. There are two ways to provide the password to the Ansible playbook without exposing it to prying eyes.
+
+1. The first method is to use a **vars_prompt** to collect the password up front one time for the playbook. Ansible will not display the password if the prompt is configured as **private** and the task will not display the password on the CLI. This is the a good method as it supports automating the task to every host with only one password entry. To enable **vars_prompt** add the following to the very top of your playbook after the **hosts** declaration and before any **pre_tasks** section:
+
+    ```
+    - hosts: localhost
+      # Add the following lines after a -hosts: declaration and before pre_tasks:
+      # Start of vars_prompt code block
+      vars_prompt:
+        - name: "rhsm_password"
+          prompt: "Subscription Manager password"
+          confirm: yes
+          private: yes
+      # End of vars_prompt code block
+      pre_tasks:
+    ```
+
+2. A second method is to use an encrypted file via **ansible-vault**. This does does not require modifying any code as the previous method, but does require more work to create and encrypt the file. To accomplish this, first create a file containing at least the **rhsm_password** variable (it is also possible to specify additional variables to encrypt them all as well):
+  1. Create a file to contain the variable such as **secrets.yml**:
+
+    ```
+    ---
+    rhsm_password: "my_secret_password"
+    # other variables can optionally be placed here as well
+    ```
+
+  2. Encrypt the file with **ansible-vault**:
+
+    ```
+    $ ansible-vault encrypt secrets.yml
+    Vault password: 
+    Confirm Vault password: 
+    Encryption successful
+    ```
+
+  3. When executing **ansible-playbook** specify **--ask-vault-pass** to be prompted for the decryption password, and also specify the location of the **secrets.yml** as such:
+
+    ```
+    $ ansible-playbook --ask-vault-pass --extra-vars=@secrets.yml --extra-vars="rhsm_username=myusername" <other playbook options>
+    ```
+
+  NOTE: Optionally the file containing the encrypted variables can be decrypted with **ansible-vault** and the **--ask-vault-pass** option omitted to prevent any password prompting (for automated runs) and the file can be encrypted after the run. This can be used if an external system such as Jenkins would handle the decryption/encryption outside of Ansible.
 
 Default: none
 
@@ -53,21 +94,24 @@ rhsm_repos='["rhel-7-server-rpms", "rhel-7-server-ose-3.1-rpms", "rhel-7-server-
 Default: none
 
 ## Calling This Role
-Calling this role requires adding a **vars_prompt**, **pre_tasks**, and **roles** section of a play
+Calling this role is done at both **pre_tasks** and **roles** sections of a playbook and optionally a **vars_prompt**.
 
 ### vars_prompt
-Unfortunately **vars_prompt** can only be used at the play level before role tasks are executed, so this is the only place it can go. See http://stackoverflow.com/questions/25466675/ansible-to-conditionally-prompt-for-a-variable
+Unfortunately **vars_prompt** can only be used at the play level before role tasks are executed, so this is the only place it can go. It also cannot be shown conditionally. For this reason it is not included in this role by default. A better method may be using a file containing the password variable encrypted with **ansible-vault**. See the **rhsm_password** section for more details.
 
-Add a prompt to capture **rhsm_password**
+To Add a prompt to capture **rhsm_password**:
 
 ```
 - hosts: localhost
+  # Add the following lines after a -hosts: declaration and before pre_tasks:
+  # Start of vars_prompt code block
   vars_prompt:
-  # Unfortunately vars_prompt can only be used at the play level before role tasks, so this is the only place it can go. See http://stackoverflow.com/questions/25466675/ansible-to-conditionally-prompt-for-a-variable
     - name: "rhsm_password"
-      prompt: "Subscription Manager password (enter blank if using rhsm_activationkey or to disable registration)"
+      prompt: "Subscription Manager password"
       confirm: yes
       private: yes
+  # End of vars_prompt code block
+  pre_tasks:
 ```
 
 ### pre-tasks
@@ -75,8 +119,8 @@ Add a prompt to capture **rhsm_password**
 A number of variable checks are performed before any tasks to ensure the proper parameters are set. To include these checks call the pre_task yaml before any roles:
 
 ```
-  pre_tasks:
-  - include: roles/subscription-manager/pre_tasks/pre_tasks.yml 
+pre_tasks:
+- include: roles/subscription-manager/pre_tasks/pre_tasks.yml 
 ```
 
 ### roles
@@ -84,22 +128,29 @@ A number of variable checks are performed before any tasks to ensure the proper 
 The bulk of the work is performed in the main.yml for this role. The pre-task play will set a variable which can be checked to contitionally include this role as such:
 
 ```
-  roles:
-    - { role: subscription-manager, when: hostvars.localhost.rhsm_register, tags: 'subscription-manager' }
+roles:
+  - { role: subscription-manager, when: hostvars.localhost.rhsm_register, tags: 'subscription-manager' }
 ```
 
-## Running the Playbook
+## Running Playbooks with this Role
  
-To register to RHSM Hosted with username and password:
+- To register to RHSM Hosted or Satellite with a username and plain text password (NOTE: This may retain your password in your CLI history):
 
-```
-ansible-playbook -i inventory/ose-provision ose-provision.yml -e "rhsm_username=vvaldez"
-```
+    ```
+    $ ansible-playbook --extra-vars="rhsm_username=vvaldez rhsm_password=my_secret_password <other playbook otions>"
+    ```
 
-To register to a Satellite server with an activation key:
+- To register to RHSM Hosted or Satellite with username and an encrypted file containing the password:
 
-```
-ansible-playbook -i inventory/ose-provision ose-provision.yml -e "rhsm_satellite=satellite.example.com rhsm_org=example_org rhsm_activationkey=rhel-7-ose-3-1"
-```
+    ```
+    $ ansible-playbook --ask-vault-pass --extra-vars=@secrets.yml --extra-vars="rhsm_username=myusername" <other playbook options>
 
-To ignore any Subscription Manager activities, simply do not set any parameters. When prompted for the password, hit **Enter** to set a blank password.
+    ```
+
+- To register to a Satellite server with an activation key:
+
+    ```
+    $ ansible-playbook --extra-vars="rhsm_satellite=satellite.example.com rhsm_org=example_org rhsm_activationkey=rhel-7-ose-3-1 <other playbook options>"
+
+    ```
+- To ignore any Subscription Manager activities, simply do not set any parameters.

--- a/rhc-ose-ansible/roles/subscription-manager/README.md
+++ b/rhc-ose-ansible/roles/subscription-manager/README.md
@@ -1,0 +1,95 @@
+# Red Hat Subscription Manager Ansible Role
+
+## Parameters
+
+This role depends on user specified variables. These can be set in the inventory file, group_vars or passed to the playbook from the CLI. The variables are:
+
+### rhsm_method
+
+Subscription Manager method to use for registration. Valid values are:
+
+* **satellite** - Use a Satellite server. Additional variables required include **rhsm_server**, **rhsm_org** and either (**rhsm_username** and **rhsm_password**) or **rhsm_activationkey**
+* **hosted** - Use Red Hat's CDN. Additional variables required are **rhsm_server** (defaults to RHSM CDN) and **rhsm_username** and **rhsm_password**
+* none/false/blank will disable any subscription manager activities (this is the default if no parameters are set)
+
+Default: none
+
+### rhsm_server
+
+Subscription Manager server hostname. If using a Satellite server set the FQDN here. If using RHSM Hosted this value is ignored.
+
+Default: none
+
+### rhsm_username
+
+Subscription Manager username. Required for RHSM Hosted. Can be optionally used for Satellite, but it may be better to use **rhsm_activationkey** for this.
+
+Default: none
+
+### rhsm_password
+
+Subscription Manager password. Required for RHSM Hosted. Can be optionally used for Satellite, but it may be better to use **rhsm_activationkey** for this.
+
+Default: none
+
+### rhsm_org
+
+Optional Satellite Subscription Manager Organization. Required for Satellite, ignored if using RHSM Hosted.
+
+Default: none
+
+### rhsm_activationkey
+
+Optional Satellite Subscription Manager Activation Key, use this instead of **rhsm_username** and **rhsm_password** if using Satellite to provide repositories and authentication in a key instead.
+
+Default: none
+
+### rhsm_pool
+
+Optional Subscription Manager pool, determine this by running **subscription-manager list --available** on a registered system. Valid for RHSM Hosted or Satellite. Specifying **rhsm_activationkey** will ignore this option.
+
+Default: none
+
+### rhsm_repos
+
+Optional Repositories to enable, this can also be specified in the **rhsm_activationkey**. Valid for RHSM Hosted or Satellite. Specifying **rhsm_activationkey** will ignore this option.
+
+NOTE: If specifying this value in an inventory file as opposed to group_vars, be sure to define it as a proper list as such:
+
+rhsm_repos='["rhel-7-server-rpms", "rhel-7-server-ose-3.1-rpms", "rhel-7-server-extras-rpms"]'
+
+Default: none
+
+## Pre-tasks
+
+A number of variable checks are performed before any tasks to ensure the proper parameters are set. To include these checks call the pre_task yaml before any roles:
+
+```
+  pre_tasks:
+  - include: roles/subscription-manager/pre_tasks/pre_tasks.yml 
+```
+
+## Tasks
+
+The bulk of the work is performed in the main.yml for this role. The pre-task play will set a variable which can be checked to contitionally include this role as such:
+
+```
+  roles:
+    - { role: subscription-manager, when: not hostvars.localhost.rhsm_skip, tags: 'subscription-manager' }
+```
+
+## Running the Playbook
+ 
+To register to RHSM Hosted with username and password:
+
+```
+ansible-playbook -i inventory/ose-provision ose-provision.yml -e "rhsm_method='hosted' rhsm_username=vvaldez rhsm_password='hunter2' openstack_key_name='vvaldez'"
+```
+
+To register to a Satellite server with an activation key:
+
+```
+ansible-playbook -i inventory/ose-provision ose-provision.yml -e "rhsm_server='10.12.32.1' rhsm_org='cloud_practice' rhsm_activationkey='rhel-7-ose-3-1' openstack_key_name='vvaldez' rhsm_method='satellite'"
+```
+
+To ignore any Subscription Manager activities, simple do not set any parameters or explicitly set **rhsm_method** to false.

--- a/rhc-ose-ansible/roles/subscription-manager/pre_tasks/pre_tasks.yml
+++ b/rhc-ose-ansible/roles/subscription-manager/pre_tasks/pre_tasks.yml
@@ -1,5 +1,5 @@
 ---
-- name: Set password fact
+- name: "Set password fact"
   set_fact:
     rhsm_password: "{{ rhsm_password }}"
   no_log: true
@@ -8,11 +8,11 @@
     - rhsm_password is not none
     - rhsm_password|trim != ''
 
-- name: Initialize Subscription Manager fact
+- name: "Initialize Subscription Manager fact"
   set_fact:
     rhsm_register: true
 
-- name: Determine if Subscription Manager should be used
+- name: "Determine if Subscription Manager should be used"
   set_fact:
     rhsm_register: false
   when: 
@@ -23,7 +23,7 @@
     - rhsm_activationkey is undefined or rhsm_activationkey is none or rhsm_activationkey|trim == ''
     - rhsm_pool is undefined or rhsm_pool is none or rhsm_pool|trim == ''
 
-- name: Validate Subscription Manager organization is set
+- name: "Validate Subscription Manager organization is set"
   fail: msg="Cannot register to a Satellite server without a value for the Organization via 'rhsm_org'"
   when: 
     - rhsm_org is undefined or rhsm_org is none or rhsm_org|trim == ''
@@ -32,14 +32,14 @@
     - rhsm_satellite|trim != ''
     - rhsm_register
 
-- name: Validate Subscription Manager authentication is defined
-  fail: msg="Cannot register without ('rhsm_username' and 'rhsm_password') or 'rhsm_activationkey' variables set"
+- name: "Validate Subscription Manager authentication is defined"
+  fail: msg="Cannot register without ('rhsm_username' and 'rhsm_password') or 'rhsm_activationkey' variables set. See the README.md for details on securely prompting for a password"
   when:
     - (rhsm_username is undefined or rhsm_username is none or rhsm_username|trim == '') or (rhsm_password is undefined or rhsm_password is none or rhsm_password|trim == '')
     - rhsm_activationkey is undefined or rhsm_activationkey is none or rhsm_activationkey|trim == ''
     - rhsm_register
 
-- name: Validate activation key and Hosted are not requested together
+- name: "Validate activation key and Hosted are not requested together"
   fail: msg="Cannot register to RHSM Hosted with 'rhsm_activationkey'"
   when:
     - rhsm_satellite is undefined or rhsm_satellite is none or rhsm_satellite|trim == ''

--- a/rhc-ose-ansible/roles/subscription-manager/pre_tasks/pre_tasks.yml
+++ b/rhc-ose-ansible/roles/subscription-manager/pre_tasks/pre_tasks.yml
@@ -1,4 +1,13 @@
 ---
+- name: Set password fact
+  set_fact:
+    rhsm_password: "{{ rhsm_password }}"
+  no_log: true
+  when:
+    - rhsm_password is defined
+    - rhsm_password is not none
+    - rhsm_password|trim != ''
+
 - name: Initialize Subscription Manager fact
   set_fact:
     rhsm_register: true

--- a/rhc-ose-ansible/roles/subscription-manager/pre_tasks/pre_tasks.yml
+++ b/rhc-ose-ansible/roles/subscription-manager/pre_tasks/pre_tasks.yml
@@ -1,0 +1,37 @@
+---
+- name: Initialize Subscription Manager fact
+  set_fact:
+    rhsm_skip: false
+
+- name: Determine if Subscription Manager should be skipped or not
+  set_fact:
+    rhsm_skip: true
+  when: rhsm_method is undefined or rhsm_method is none or rhsm_method|trim == ''
+
+- name: Determine Subscription Manager method
+  fail: msg="Value for 'rhsm_method' of '{{ rhsm_method }}' is not valid, it should be one of 'hosted', 'satellite', or false/none/blank"
+  when: 
+    - rhsm_method != 'hosted' and rhsm_method != 'satellite'
+    - not rhsm_skip
+
+- name: Validate Subscription Manager host is set
+  fail: msg="Cannot determine Subscription Manager server hostname without a value for 'rhsm_server'"
+  when: 
+    - rhsm_server is undefined or rhsm_server is none or rhsm_server|trim == ''
+    - not rhsm_method == 'hosted'
+    - not rhsm_skip
+
+- name: Validate Subscription Manager organization is set
+  fail: msg="Cannot register to a Satellite server without a value for the Organization via 'rhsm_org'"
+  when: 
+    - rhsm_org is undefined or rhsm_org is none or rhsm_org|trim == ''
+    - rhsm_method == 'satellite'
+    - not rhsm_skip
+
+- name: Validate Subscription Manager authentication is defined
+  fail: msg="Cannot register without ('rhsm_username' and 'rhsm_password') or 'rhsm_activationkey' variables set"
+  when:
+    - (rhsm_username is undefined or rhsm_username is none or rhsm_username|trim == '') or (rhsm_password is undefined or rhsm_password is none or rhsm_password|trim == '')
+    - rhsm_activationkey is undefined or rhsm_activationkey is none or rhsm_activationkey|trim == ''
+    - not rhsm_skip
+

--- a/rhc-ose-ansible/roles/subscription-manager/pre_tasks/pre_tasks.yml
+++ b/rhc-ose-ansible/roles/subscription-manager/pre_tasks/pre_tasks.yml
@@ -1,37 +1,40 @@
 ---
 - name: Initialize Subscription Manager fact
   set_fact:
-    rhsm_skip: false
+    rhsm_register: true
 
-- name: Determine if Subscription Manager should be skipped or not
+- name: Determine if Subscription Manager should be used
   set_fact:
-    rhsm_skip: true
-  when: rhsm_method is undefined or rhsm_method is none or rhsm_method|trim == ''
-
-- name: Determine Subscription Manager method
-  fail: msg="Value for 'rhsm_method' of '{{ rhsm_method }}' is not valid, it should be one of 'hosted', 'satellite', or false/none/blank"
+    rhsm_register: false
   when: 
-    - rhsm_method != 'hosted' and rhsm_method != 'satellite'
-    - not rhsm_skip
-
-- name: Validate Subscription Manager host is set
-  fail: msg="Cannot determine Subscription Manager server hostname without a value for 'rhsm_server'"
-  when: 
-    - rhsm_server is undefined or rhsm_server is none or rhsm_server|trim == ''
-    - not rhsm_method == 'hosted'
-    - not rhsm_skip
+    - rhsm_satellite is undefined or rhsm_satellite is none or rhsm_satellite|trim == ''
+    - rhsm_username is undefined or rhsm_username is none or rhsm_username|trim == ''
+    - rhsm_password is undefined or rhsm_password is none or rhsm_password|trim == ''
+    - rhsm_org is undefined or rhsm_org is none or rhsm_org|trim == ''
+    - rhsm_activationkey is undefined or rhsm_activationkey is none or rhsm_activationkey|trim == ''
+    - rhsm_pool is undefined or rhsm_pool is none or rhsm_pool|trim == ''
 
 - name: Validate Subscription Manager organization is set
   fail: msg="Cannot register to a Satellite server without a value for the Organization via 'rhsm_org'"
   when: 
     - rhsm_org is undefined or rhsm_org is none or rhsm_org|trim == ''
-    - rhsm_method == 'satellite'
-    - not rhsm_skip
+    - rhsm_satellite is defined
+    - rhsm_satellite is not none
+    - rhsm_satellite|trim != ''
+    - rhsm_register
 
 - name: Validate Subscription Manager authentication is defined
   fail: msg="Cannot register without ('rhsm_username' and 'rhsm_password') or 'rhsm_activationkey' variables set"
   when:
     - (rhsm_username is undefined or rhsm_username is none or rhsm_username|trim == '') or (rhsm_password is undefined or rhsm_password is none or rhsm_password|trim == '')
     - rhsm_activationkey is undefined or rhsm_activationkey is none or rhsm_activationkey|trim == ''
-    - not rhsm_skip
+    - rhsm_register
 
+- name: Validate activation key and Hosted are not requested together
+  fail: msg="Cannot register to RHSM Hosted with 'rhsm_activationkey'"
+  when:
+    - rhsm_satellite is undefined or rhsm_satellite is none or rhsm_satellite|trim == ''
+    - rhsm_activationkey is defined
+    - rhsm_activationkey is not none
+    - rhsm_activationkey|trim != ''
+    - rhsm_register

--- a/rhc-ose-ansible/roles/subscription-manager/tasks/main.yml
+++ b/rhc-ose-ansible/roles/subscription-manager/tasks/main.yml
@@ -32,7 +32,7 @@
   changed_when: no
   register: check_if_registered
 
-- name: Set registration fact
+- name: Set registration fact if system is already registered
   set_fact:
     registered: true
   when: check_if_registered.rc == 0
@@ -44,17 +44,21 @@
     - rhsm_authentication is defined
 
 - name: Install Satellite certificate
-  command: "rpm -Uvh --force http://{{ rhsm_server }}/pub/katello-ca-consumer-latest.noarch.rpm"
+  command: "rpm -Uvh --force http://{{ rhsm_satellite }}/pub/katello-ca-consumer-latest.noarch.rpm"
   when:
     - not registered
-    - rhsm_method == 'satellite'
+    - rhsm_satellite is defined
+    - rhsm_satellite is not none
+    - rhsm_satellite|trim != ''
 
 - name: Register to Satellite using activation key
   command: "/usr/bin/subscription-manager register --activationkey={{ rhsm_activationkey }} --org={{ rhsm_org }}"
   when:
     - not registered
     - rhsm_authentication == 'key'
-    - rhsm_method == 'satellite'
+    - rhsm_satellite is defined
+    - rhsm_satellite is not none
+    - rhsm_satellite|trim != ''
 
 # This can apply to either Hosted or Satellite
 - name: Register using username and password
@@ -80,14 +84,18 @@
   command: "/usr/bin/subscription-manager repos --disable=*"
   when:
     - not registered
-    - not rhsm_authentication == "key"
+    - rhsm_repos is defined
+    - rhsm_repos is not none
+    - rhsm_repos|trim != ''
 
 - name: Enable specified repositories
   command: "/usr/bin/subscription-manager repos --enable={{ item }}"
   with_items: rhsm_repos
   when:
     - not registered
-    - not rhsm_authentication == "key"
+    - rhsm_repos is defined
+    - rhsm_repos is not none
+    - rhsm_repos|trim != ''
 
 - name: Cleaning yum repositories
   command: "yum clean all"

--- a/rhc-ose-ansible/roles/subscription-manager/tasks/main.yml
+++ b/rhc-ose-ansible/roles/subscription-manager/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Initializing Subscription Manager authenticaiton method
   set_fact:
     rhsm_authentication: false
@@ -61,6 +62,7 @@
     - rhsm_satellite|trim != ''
 
 # This can apply to either Hosted or Satellite
+
 - name: Register using username and password
   command: "/usr/bin/subscription-manager register --username={{ rhsm_username }} --password={{ rhsm_password }}"
   when:
@@ -72,12 +74,15 @@
   when:
     - not registered
     - rhsm_authentication != "key"
+    - rhsm_pool is undefined or rhsm_pool is none or rhsm_pool|trim == ''
 
 - name: Attach to a specific pool
   command: "/usr/bin/subscription-manager attach --pool={{ rhsm_pool }}"
   when:
-    - rhsm_pool is defined and rhsm_pool is not none and rhsm_pool|trim != ''
-    - and not registered
+    - rhsm_pool is defined
+    - rhsm_pool is not none
+    - rhsm_pool|trim != ''
+    - not registered
     - rhsm_authentication != "key"
 
 - name: Disable all repositories

--- a/rhc-ose-ansible/roles/subscription-manager/tasks/main.yml
+++ b/rhc-ose-ansible/roles/subscription-manager/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Initialize rhsm_password variable if vars_prompt was used
+- name: "Initialize rhsm_password variable if vars_prompt was used"
   set_fact:
     rhsm_password: "{{ hostvars.localhost.rhsm_password }}"
   when:
@@ -7,12 +7,12 @@
       - rhsm_password is not none
       - rhsm_password|trim != ''
   
-- name: Initializing Subscription Manager authenticaiton method
+- name: "Initializing Subscription Manager authenticaiton method"
   set_fact:
     rhsm_authentication: false
 
 # 'rhsm_activationkey' will take precedence even if 'rhsm_username' and 'rhsm_password' are also set
-- name: Setting Subscription Manager Activation Key Fact
+- name: "Setting Subscription Manager Activation Key Fact"
   set_fact:
     rhsm_authentication: "key"
   when:
@@ -22,7 +22,7 @@
     - not rhsm_authentication
 
 # If 'rhsm_username' and 'rhsm_password' are set but not 'rhsm_activationkey', set 'rhsm_authentication' to password
-- name: Setting Subscription Manager Username and Password Fact
+- name: "Setting Subscription Manager Username and Password Fact"
   set_fact:
     rhsm_authentication: "password"
   when:
@@ -34,28 +34,28 @@
     - rhsm_password|trim != ''
     - not rhsm_authentication
 
-- name: Initializing registration status
+- name: "Initializing registration status"
   set_fact:
     registered: false
 
-- name: Checking subscription status (a failure means it is not registered and will be)
+- name: "Checking subscription status (a failure means it is not registered and will be)"
   command: "/usr/bin/subscription-manager status"
   ignore_errors: yes
   changed_when: no
   register: check_if_registered
 
-- name: Set registration fact if system is already registered
+- name: "Set registration fact if system is already registered"
   set_fact:
     registered: true
   when: check_if_registered.rc == 0
 
-- name: Cleaning any old subscriptions
+- name: "Cleaning any old subscriptions"
   command: "/usr/bin/subscription-manager clean"
   when:
     - not registered
     - rhsm_authentication is defined
 
-- name: Install Satellite certificate
+- name: "Install Satellite certificate"
   command: "rpm -Uvh --force http://{{ rhsm_satellite }}/pub/katello-ca-consumer-latest.noarch.rpm"
   when:
     - not registered
@@ -63,7 +63,7 @@
     - rhsm_satellite is not none
     - rhsm_satellite|trim != ''
 
-- name: Register to Satellite using activation key
+- name: "Register to Satellite using activation key"
   command: "/usr/bin/subscription-manager register --activationkey={{ rhsm_activationkey }} --org={{ rhsm_org }}"
   when:
     - not registered
@@ -73,20 +73,20 @@
     - rhsm_satellite|trim != ''
 
 # This can apply to either Hosted or Satellite
-- name: Register using username and password
+- name: "Register using username and password"
   command: "/usr/bin/subscription-manager register --username={{ rhsm_username }} --password={{ rhsm_password }}"
   no_log: true
   when:
     - not registered
     - rhsm_authentication == "password"
 
-- name: Auto-attach to Subscription Manager Pool
+- name: "Auto-attach to Subscription Manager Pool"
   command: "/usr/bin/subscription-manager attach --auto"
   when:
     - not registered
     - rhsm_pool is undefined or rhsm_pool is none or rhsm_pool|trim == ''
 
-- name: Attach to a specific pool
+- name: "Attach to a specific pool"
   command: "/usr/bin/subscription-manager attach --pool={{ rhsm_pool }}"
   when:
     - rhsm_pool is defined
@@ -94,7 +94,7 @@
     - rhsm_pool|trim != ''
     - not registered
 
-- name: Disable all repositories
+- name: "Disable all repositories"
   command: "/usr/bin/subscription-manager repos --disable=*"
   when:
     - not registered
@@ -102,7 +102,7 @@
     - rhsm_repos is not none
     - rhsm_repos|trim != ''
 
-- name: Enable specified repositories
+- name: "Enable specified repositories"
   command: "/usr/bin/subscription-manager repos --enable={{ item }}"
   with_items: rhsm_repos
   when:
@@ -110,6 +110,3 @@
     - rhsm_repos is defined
     - rhsm_repos is not none
     - rhsm_repos|trim != ''
-
-- name: Cleaning yum repositories
-  command: "yum clean all"

--- a/rhc-ose-ansible/roles/subscription-manager/tasks/main.yml
+++ b/rhc-ose-ansible/roles/subscription-manager/tasks/main.yml
@@ -3,9 +3,7 @@
   set_fact:
     rhsm_password: "{{ hostvars.localhost.rhsm_password }}"
   when:
-      - rhsm_password is defined
-      - rhsm_password is not none
-      - rhsm_password|trim != ''
+    - rhsm_password is not defined or rhsm_password is none or rhsm_password|trim == ''
   
 - name: "Initializing Subscription Manager authenticaiton method"
   set_fact:

--- a/rhc-ose-ansible/roles/subscription-manager/tasks/main.yml
+++ b/rhc-ose-ansible/roles/subscription-manager/tasks/main.yml
@@ -1,0 +1,93 @@
+---
+- name: Initializing Subscription Manager authenticaiton method
+  set_fact:
+    rhsm_authentication: false
+
+# 'rhsm_activationkey' will take precedence even if 'rhsm_username' and 'rhsm_password' are also set
+- name: Setting Subscription Manager Activation Key Fact
+  set_fact:
+    rhsm_authentication: "key"
+  when:
+    - rhsm_activationkey is defined
+    - rhsm_activationkey is not none
+    - rhsm_activationkey|trim != ''
+    - not rhsm_authentication
+
+# If 'rhsm_username' and 'rhsm_password' are set but not 'rhsm_activationkey', set 'rhsm_authentication' to password
+- name: Setting Subscription Manager Username and Password Fact
+  set_fact:
+    rhsm_authentication: "password"
+  when:
+    - rhsm_username is defined and rhsm_username is not none and rhsm_username|trim != ''
+    - rhsm_password is defined and rhsm_password is not none and rhsm_password|trim != ''
+    - not rhsm_authentication
+
+- name: Initializing registration status
+  set_fact:
+    registered: false
+
+- name: Checking subscription status (a failure means it is not registered and will be)
+  command: "/usr/bin/subscription-manager status"
+  ignore_errors: yes
+  changed_when: no
+  register: check_if_registered
+
+- name: Set registration fact
+  set_fact:
+    registered: true
+  when: check_if_registered.rc == 0
+
+- name: Cleaning any old subscriptions
+  command: "/usr/bin/subscription-manager clean"
+  when:
+    - not registered
+    - rhsm_authentication is defined
+
+- name: Install Satellite certificate
+  command: "rpm -Uvh --force http://{{ rhsm_server }}/pub/katello-ca-consumer-latest.noarch.rpm"
+  when:
+    - not registered
+    - rhsm_method == 'satellite'
+
+- name: Register to Satellite using activation key
+  command: "/usr/bin/subscription-manager register --activationkey={{ rhsm_activationkey }} --org={{ rhsm_org }}"
+  when:
+    - not registered
+    - rhsm_authentication == 'key'
+    - rhsm_method == 'satellite'
+
+# This can apply to either Hosted or Satellite
+- name: Register using username and password
+  command: "/usr/bin/subscription-manager register --username={{ rhsm_username }} --password={{ rhsm_password }}"
+  when:
+    - not registered
+    - rhsm_authentication != "key"
+
+- name: Auto-attach to Subscription Manager Pool
+  command: "/usr/bin/subscription-manager attach --auto"
+  when:
+    - not registered
+    - rhsm_authentication != "key"
+
+- name: Attach to a specific pool
+  command: "/usr/bin/subscription-manager attach --pool={{ rhsm_pool }}"
+  when:
+    - rhsm_pool is defined and rhsm_pool is not none and rhsm_pool|trim != ''
+    - and not registered
+    - rhsm_authentication != "key"
+
+- name: Disable all repositories
+  command: "/usr/bin/subscription-manager repos --disable=*"
+  when:
+    - not registered
+    - not rhsm_authentication == "key"
+
+- name: Enable specified repositories
+  command: "/usr/bin/subscription-manager repos --enable={{ item }}"
+  with_items: rhsm_repos
+  when:
+    - not registered
+    - not rhsm_authentication == "key"
+
+- name: Cleaning yum repositories
+  command: "yum clean all"

--- a/rhc-ose-ansible/roles/subscription-manager/tasks/main.yml
+++ b/rhc-ose-ansible/roles/subscription-manager/tasks/main.yml
@@ -1,5 +1,12 @@
 ---
-
+- name: Initialize rhsm_password variable if vars_prompt was used
+  set_fact:
+    rhsm_password: "{{ hostvars.localhost.rhsm_password }}"
+  when:
+      - rhsm_password is defined
+      - rhsm_password is not none
+      - rhsm_password|trim != ''
+  
 - name: Initializing Subscription Manager authenticaiton method
   set_fact:
     rhsm_authentication: false
@@ -19,8 +26,12 @@
   set_fact:
     rhsm_authentication: "password"
   when:
-    - rhsm_username is defined and rhsm_username is not none and rhsm_username|trim != ''
-    - rhsm_password is defined and rhsm_password is not none and rhsm_password|trim != ''
+    - rhsm_username is defined
+    - rhsm_username is not none
+    - rhsm_username|trim != ''
+    - rhsm_password is defined
+    - rhsm_password is not none
+    - rhsm_password|trim != ''
     - not rhsm_authentication
 
 - name: Initializing registration status
@@ -62,18 +73,17 @@
     - rhsm_satellite|trim != ''
 
 # This can apply to either Hosted or Satellite
-
 - name: Register using username and password
   command: "/usr/bin/subscription-manager register --username={{ rhsm_username }} --password={{ rhsm_password }}"
+  no_log: true
   when:
     - not registered
-    - rhsm_authentication != "key"
+    - rhsm_authentication == "password"
 
 - name: Auto-attach to Subscription Manager Pool
   command: "/usr/bin/subscription-manager attach --auto"
   when:
     - not registered
-    - rhsm_authentication != "key"
     - rhsm_pool is undefined or rhsm_pool is none or rhsm_pool|trim == ''
 
 - name: Attach to a specific pool
@@ -83,7 +93,6 @@
     - rhsm_pool is not none
     - rhsm_pool|trim != ''
     - not registered
-    - rhsm_authentication != "key"
 
 - name: Disable all repositories
   command: "/usr/bin/subscription-manager repos --disable=*"


### PR DESCRIPTION
#### What does this PR do?

Adds a subscription-manager role that can support RHSM Hosted or a Satellite server. Authentication can be username/password or an activation key. Repositories can also be passed in as a parameter.
#### How should this be manually tested?

First refer to the subscription-manager role from a playbook, then set the variables appropriate to your scenario. A full README has been included to describe all parameters.

To use a username/password securely with **ansible-vault**:
1. Create a file to contain the variable such as **secrets.yml**:
   
   ```
   ---
   rhsm_password: "my_secret_password"
   # other variables can optionally be placed here as well
   ```
2. Encrypt the file with **ansible-vault**:
   
   ```
   $ ansible-vault encrypt secrets.yml
   Vault password: 
   Confirm Vault password: 
   Encryption successful
   ```
3. When executing **ansible-playbook** specify **--ask-vault-pass** to be prompted for the decryption password, and also specify the location of the **secrets.yml** as such:
   
   ```
   $ ansible-playbook --ask-vault-pass --extra-vars=@secrets.yml --extra-vars="rhsm_username=myusername" <other playbook options>
   ```
#### Is there a relevant Issue open for this?

No known issues.
#### Who would you like to review this?

/cc @oybed @etsauer @sabre1041 
