### PR TITLE
Add OpenStack SSH key parameter check

### DIFF
--- a/rhc-ose-ansible/ose-provision.yml
+++ b/rhc-ose-ansible/ose-provision.yml
@@ -2,6 +2,7 @@
 # Provision OpenStack instances
 - hosts: localhost
   pre_tasks:
+  - include: roles/openstack-create/pre_tasks/pre_tasks.yml
   - include: roles/common/pre_tasks/pre_tasks.yml
   roles:
     - role: common

--- a/rhc-ose-ansible/roles/openstack-create/pre_tasks/pre_tasks.yml
+++ b/rhc-ose-ansible/roles/openstack-create/pre_tasks/pre_tasks.yml
@@ -1,0 +1,4 @@
+---
+- name: Validate OpenStack SSH key is defined
+  fail: msg="Required 'openstack_key_name' is not defined!"
+  when: openstack_key_name is undefined or openstack_key_name is none or openstack_key_name|trim == ''


### PR DESCRIPTION
#### What does this PR do?

Adds a check for the openstack_key_name parameter value. If it is not set it will fail and halt the playbook. The reason for this is if no key_name is set, the playbook will create instances but have no way to SSH into them so any remaining tasks will fail.
#### How should this be manually tested?

Attempt to run _ose-provision.yml_ without openstack_key_name set. With this PR this will be caught in a pre_task run.
#### Is there a relevant Issue open for this?

No known issues.
#### Who would you like to review this?

/cc @oybed 
