### PR TITLE
Add OpenStack security group detection and creation

### DIFF
--- a/rhc-ose-ansible/roles/openstack-create/tasks/main.yml
+++ b/rhc-ose-ansible/roles/openstack-create/tasks/main.yml
@@ -4,6 +4,55 @@
   when: 
        - image_name is not defined or security_groups is not defined or key_name is not defined or image_name is not defined or flavor_name is not defined or env_id is not defined
 
+# vvaldez - Using loops assuming there may be multiple security groups for each host type
+# also including both nova and neutron commands for compatibility or possible future decision making
+- name: "Check for Security Groups"
+  shell: "nova secgroup-list | grep {{ item }}"
+  #shell: "neutron security-group-list | grep {{ item }}"
+  with_items: "{{ security_groups }}"
+  ignore_errors: yes
+  changed_when: no
+  register: secgroup_exists
+
+#- debug: var=secgroup_exists
+
+- name: "Create Security Group"
+  shell: "nova secgroup-create {{ item.item }} {{ item.item }}"
+  #shell: "neutron security-group-create {{ item.item }}"
+  register: secgroup_create
+  when: "{{ item.rc != 0 }}"
+  with_items: "{{ secgroup_exists.results }}"
+
+#- debug: var=secgroup_create 
+
+# vvaldez - Need to add validation, if a security group existed, then the shell command wasn't run, so there is no rc to check which causes an error)
+#- name: Validate Security Group Creation
+#  fail: msg="Unable to create Security Group {{ item.item }}"
+#  when: "{{ item.rc != 0 }}"
+#  with_items: "{{ secgroup_create.results }}"
+
+- name: "Check for SSH rule in security groups"
+  shell: "nova secgroup-list-rules {{ item }} | grep 'tcp.*22'"
+  #shell: "neutron security-group-rule-list | grep \"{{ item }}.*22/tcp\""
+  with_items: "{{ security_groups }}"
+  ignore_errors: yes
+  changed_when: no
+  register: secgroup_rule
+
+- name: "Create SSH Rule in Security Group"
+  shell: "nova secgroup-add-rule {{ item.item }} tcp 22 22 0.0.0.0/0"
+  #shell: "neutron security-group-rule-create --protocol tcp --port-range-min 22 --port-range-max 22 --direction ingress {{ item.item }}"
+  register: secgroup_rule_create
+  when: "{{ item.rc != 0 }}"
+  with_items: "{{ secgroup_rule.results }}"
+
+# vvaldez - Need to add validation, if a security group rule existed, then the shell command wasn't run, so there is no rc to check which causes an error)
+#- name: Validate Security Group Rule for SSH
+#  fail: msg="Unable to create Security Group Rule for SSH"
+#  vvaldez - attempted checking the changed status, did not work
+#  when: secgroup_rule_create.changed|{{ item.rc != 0 }}
+#  with_items: "{{ secgroup_rule_create.results }}"
+
 - name: "Search for valid OpenStack Flavor"
   shell: "nova flavor-list | awk \"/{{flavor_name }}/\"'{print $2}'"
   register: flavor_query

--- a/rhc-ose-ansible/roles/openstack-create/tasks/main.yml
+++ b/rhc-ose-ansible/roles/openstack-create/tasks/main.yml
@@ -4,54 +4,40 @@
   when: 
        - image_name is not defined or security_groups is not defined or key_name is not defined or image_name is not defined or flavor_name is not defined or env_id is not defined
 
-# vvaldez - Using loops assuming there may be multiple security groups for each host type
-# also including both nova and neutron commands for compatibility or possible future decision making
+# including both nova and neutron commands for compatibility and possible future decision making
 - name: "Check for Security Groups"
-  shell: "nova secgroup-list | grep {{ item }}"
-  #shell: "neutron security-group-list | grep {{ item }}"
-  with_items: "{{ security_groups }}"
-  ignore_errors: yes
-  changed_when: no
-  register: secgroup_exists
+  shell: "nova secgroup-list"
+  #shell: "neutron security-group-list"
+  with_items: security_groups.split(',')
+  register: secgroup_list
 
-#- debug: var=secgroup_exists
-
-- name: "Create Security Group"
+- name: "Create Security Groups if required"
   shell: "nova secgroup-create {{ item.item }} {{ item.item }}"
   #shell: "neutron security-group-create {{ item.item }}"
-  register: secgroup_create
-  when: "{{ item.rc != 0 }}"
-  with_items: "{{ secgroup_exists.results }}"
+  when: not item.stdout | search('{{ item.item }}')
+  with_items: secgroup_list.results
 
-#- debug: var=secgroup_create 
+- name: "Initialize SSH rule fact"
+  set_fact:
+    ssh_rule_found: false
 
-# vvaldez - Need to add validation, if a security group existed, then the shell command wasn't run, so there is no rc to check which causes an error)
-#- name: Validate Security Group Creation
-#  fail: msg="Unable to create Security Group {{ item.item }}"
-#  when: "{{ item.rc != 0 }}"
-#  with_items: "{{ secgroup_create.results }}"
+- name: "Check for SSH rule in Security Groups"
+  shell: "nova secgroup-list-rules {{ item }}"
+  #shell: "neutron security-group-rule-list"
+  with_items: security_groups.split(',')
+  register: secgroup_rule_list
 
-- name: "Check for SSH rule in security groups"
-  shell: "nova secgroup-list-rules {{ item }} | grep 'tcp.*22'"
-  #shell: "neutron security-group-rule-list | grep \"{{ item }}.*22/tcp\""
-  with_items: "{{ security_groups }}"
-  ignore_errors: yes
-  changed_when: no
-  register: secgroup_rule
+- name: "Set SSH rule fact on match"
+  set_fact:
+    ssh_rule_found: true
+  when: item.stdout | search('tcp.*22.*22')
+  #For Neutron - when: item.stdout| search('22/tcp')
+  with_items: secgroup_rule_list.results
 
-- name: "Create SSH Rule in Security Group"
-  shell: "nova secgroup-add-rule {{ item.item }} tcp 22 22 0.0.0.0/0"
-  #shell: "neutron security-group-rule-create --protocol tcp --port-range-min 22 --port-range-max 22 --direction ingress {{ item.item }}"
-  register: secgroup_rule_create
-  when: "{{ item.rc != 0 }}"
-  with_items: "{{ secgroup_rule.results }}"
-
-# vvaldez - Need to add validation, if a security group rule existed, then the shell command wasn't run, so there is no rc to check which causes an error)
-#- name: Validate Security Group Rule for SSH
-#  fail: msg="Unable to create Security Group Rule for SSH"
-#  vvaldez - attempted checking the changed status, did not work
-#  when: secgroup_rule_create.changed|{{ item.rc != 0 }}
-#  with_items: "{{ secgroup_rule_create.results }}"
+- name: "Create SSH Rule in first Security Group if required"
+  shell: nova secgroup-add-rule {{ security_groups.split(',').0 }} tcp 22 22 0.0.0.0/0
+  #shell: neutron security-group-rule-create --protocol tcp --port-range-min 22 --port-range-max 22 --direction ingress {{ security_groups.split(',').0 }}
+  when: not ssh_rule_found
 
 - name: "Search for valid OpenStack Flavor"
   shell: "nova flavor-list | awk \"/{{flavor_name }}/\"'{print $2}'"


### PR DESCRIPTION
#### What does this PR do?

Adds check for any defined security groups and SSH rule. If these do not exist these tasks will attempt to create them.
#### How should this be manually tested?

Delete any security groups before running ose-provision.yml. The security groups and SSH rule will be created before attempting to provision instances.
#### Is there a relevant Issue open for this?

No current issues
#### Who would you like to review this?

/cc @oybed @etsauer @sabre1041 
