### PR TITLE
added HA etcd data stores for OSE

### DIFF
--- a/provisioning/lib/constants
+++ b/provisioning/lib/constants
@@ -32,6 +32,7 @@ security_group_node="ose3-node"
 security_group_cicd="CI-CD"
 os_flavor="m1.medium"
 master_is_node=true
+etcd_on_master=true
 platform="openstack" # Only one we support
 image_name_30="ose3_0-base"
 image_name_31="ose3_1-base"

--- a/provisioning/lib/helpers
+++ b/provisioning/lib/helpers
@@ -24,12 +24,12 @@ ${message}" $exit_code
 # Usage: get_hostnames "<ip address>,<ip address>,...,<ip address>" "<base dn>" "[<dns server ip>]"
 get_hostnames() {
   # Can reverse lookup hostname for an ip with
-  # dig -x 172.16.166.11 | sed -ne 's/.*\(node[0-9]*.ose.example.com\).*/\1/p'
+  # dig -x 172.16.166.11 | sed -ne 's/.*\(\(node\|etcd\)[0-9]*.ose.example.com\).*/\1/p'
   if [ -n "$3" ]; then
     local nameserver="@${3}"
   fi
   for ip in ${1//,/ }; do
-    hostnames="${hostnames},$(dig $nameserver -x $ip | sed -n "s/.*\(\(master\|node\)[0-9]*.${2}\).*/\1/p" | sort | head -n1)"
+    hostnames="${hostnames},$(dig $nameserver -x $ip | sed -n "s/.*\(\(master\|etcd\|node\)[0-9]*.${2}\).*/\1/p" | sort | head -n1)"
   done
   # Strip off leading comma
   echo ${hostnames#,*}

--- a/provisioning/osc-dns-config
+++ b/provisioning/osc-dns-config
@@ -63,6 +63,7 @@ function usage()
 {
   echo "Usage: "
   echo "  $0 -m=|--master=\"<master1 private ip|master1 public ip>,...,<masterN private ip|masterN public ip>\""
+  echo "                   -e=|--etcd=\"<etcd1 private ip|etcd1 public ip>,...,<etcdN private ip|etcdN public ip>\""
   echo "                   -n=|--nodes=\"<node1 private ip|node1 public ip>,...,<nodeN private ip|nodeN public ip>\""
   echo "                   -b=|--base_domain=\"<base domain>\""
   echo "                   -d=|--dns_host=\"<DNS host private ip|DHS host public ip>\""
@@ -71,6 +72,7 @@ function usage()
   echo ""
   echo "  where:"
   echo "    -m|--master      : comma separated list of master instances, private and public IPs separated by '|'"
+  echo "    -e|--etcd        : comma separated list of etcd instances, private and public IPs separated by '|'"
   echo "    -n|--nodes       : comma separated list of node instances, private and public IPs separated by '|'"
   echo "    -b|--base_domain : base DNS domain for use with the master(s) and nodes"
   echo "    -d|--dns_host    : server to use for hosting DNS (bind), private and public IPs separated by '|'"
@@ -391,6 +393,11 @@ do
       shift
     ;;
 
+    -e=*|--etcd=*)
+      ETCD="${i#*=}"
+      shift
+    ;;
+
     -n=*|--nodes=*)
       NODES="${i#*=}"
       shift
@@ -442,6 +449,7 @@ fi
 
 
 IFS=',' read -a masters <<< "${MASTER}"
+IFS=',' read -a etcds <<< "${ETCD}"
 IFS=',' read -a nodes <<< "${NODES}"
 
 dh_private_ip=${DNS_HOST%|*}
@@ -504,6 +512,38 @@ do
   i=$((i+1))
 done
 
+i=
+[ ${#etcds[@]} -gt 1 ] && i=1
+
+for e in "${etcds[@]}"
+do
+  privateip=${e%|*}
+  publicip=${e#*|}
+  if [ -z "${privateip}" -o \
+       -z "${publicip}" ]
+  then
+    echo "Invalid etcd IP combination for ${e}"
+    usage
+    exit 1
+  fi
+
+  echo "DNS : Setting config for etcd - ${privateip}|${publicip} ..."
+
+  prepPTRConfig ${dh_private_ip} ${privateip} ${BASE_DOMAIN} PRIVATE
+  prepPTRConfig ${dh_private_ip} ${publicip} ${BASE_DOMAIN} PUBLIC
+
+  createDNSrecord ${dh_private_ip} ${privateip} ${publicip} "etcd${i}" "A"
+  createDNSrecord ${dh_private_ip} ${privateip} ${publicip} "etcd${i}.${BASE_DOMAIN}" "PTR"
+
+  setHostname ${privateip} etcd${i}.${BASE_DOMAIN}
+  sleep 1
+  setDNSservers ${privateip} ${BASE_DOMAIN} ${dh_private_ip}
+
+  subnet=`ipcalc -n "${privateip}/${DEFAULT_SUBNET_SIZE}" | sed -ne 's/NETWORK=\(.*\)/\1/p'`
+  contains "${subnet}" "${A_ACLlist[@]}" || A_ACLlist+=(${subnet})
+
+  i=$((i+1))
+done
 
 i=
 [ ${#masters[@]} -gt 1 ] && i=1

--- a/provisioning/osc-install
+++ b/provisioning/osc-install
@@ -8,7 +8,7 @@ source ${SCRIPT_BASE_DIR}/lib/constants
 
 # Show script usage
 usage() {
-  echo "Usage: $0 -m=|--master=\"<master1 private ip|master1 public ip>\" -n=|--nodes=\"<node1 private ip|node1 public ip>,...,<nodeN private ip|nodeN public ip>\" -a|--actions=\"action1,action2,...actionN\""
+  echo "Usage: $0 -m=|--master=\"<master1 private ip|master1 public ip>\" -e=|--etcd=\"<etcd1 private ip|etcd1 public ip>,...,<etcdN private ip|etcdN public ip>\" -n=|--nodes=\"<node1 private ip|node1 public ip>,...,<nodeN private ip|nodeN public ip>\" -a|--actions=\"action1,action2,...actionN\""
 }
 
 # Determine whether master is a node, and if not, make node1 the 'infra' node
@@ -73,14 +73,31 @@ EOF
 
   done
 
+#  if [ !$etcd_on_master ]; then
+#    mv ${SCRIPT_BASE_DIR}/templates/ansible-hosts ${SCRIPT_BASE_DIR}/templates/ansible-hosts.template
+#    sed '/^{{MASTER_HOSTNAME}}$/d' ${SCRIPT_BASE_DIR}/templates/ansible-hosts.template > ${SCRIPT_BASE_DIR}/templates/ansible-hosts
+#  fi
+
+#  ETCD_HOST_NAMES=`echo $ETCD_HOSTNAMES | sed 's/,/\\\n/g'`
+  for etcd in ${ETCD_HOSTNAMES//,/ }; do
+    # This is a hack to make sure we don't get host key checks during ansible run
+    validate_ssh ${etcd}
+
+    read -d '' ETCDSTRING <<EOF
+$ETCDSTRING
+${etcd} openshift_hostname=${etcd} openshift_public_hostname=${etcd}
+EOF
+
+  done
+
   # Prepare the apps sub domain:
   CLOUDAPPS_SUBDOMAIN="${OPENSHIFT_CLOUDAPPS_SUBDOMAIN}.${OPENSHIFT_BASE_DOMAIN}"
 
   if [ -z "${OPENSHIFT_IDENTITY_PROVIDER_JSON}" ]; then
     error_out "OPENSHIFT_IDENTITY_PROVIDER_JSON cannot be empty: ${OPENSHIFT_IDENTITY_PROVIDER_JSON}"
   fi
-  echo "process_template ${SCRIPT_BASE_DIR}/templates/ansible-hosts MASTER_HOSTNAME NODESTRING CLOUDAPPS_SUBDOMAIN OPENSHIFT_IDENTITY_PROVIDER_JSON"
-  ansible_hosts_file="$(process_template ${SCRIPT_BASE_DIR}/templates/ansible-hosts MASTER_HOSTNAME NODESTRING CLOUDAPPS_SUBDOMAIN OPENSHIFT_IDENTITY_PROVIDER_JSON)"
+  echo "process_template ${SCRIPT_BASE_DIR}/templates/ansible-hosts MASTER_HOSTNAME ETCDSTRING NODESTRING CLOUDAPPS_SUBDOMAIN OPENSHIFT_IDENTITY_PROVIDER_JSON"
+  ansible_hosts_file="$(process_template ${SCRIPT_BASE_DIR}/templates/ansible-hosts MASTER_HOSTNAME ETCDSTRING NODESTRING CLOUDAPPS_SUBDOMAIN OPENSHIFT_IDENTITY_PROVIDER_JSON)"
 
   cd
   rm -rf ~/openshift-ansible
@@ -145,7 +162,7 @@ setup_storage() {
 }
 
 setup_storage_on_all_hosts() {
-  for host in ${MASTER_HOSTNAME} ${NODE_HOSTNAMES//,/ }; do
+  for host in ${MASTER_HOSTNAME} ${NODE_HOSTNAMES//,/ } ${ETCD_HOSTNAMES//,/ }; do
     ${SSH_CMD} root@${host} "$(typeset -f); $(typeset -p OPENSHIFT_STORAGE_DISK_VOLUME); $(typeset -p OPENSHIFT_STORAGE_SIZE_OSE); $(typeset -p OPENSHIFT_STORAGE_SIZE_ETCD); $(typeset -p OPENSHIFT_STORAGE_SIZE_LOGGING); setup_storage"
   done
 }
@@ -170,7 +187,7 @@ do_prep() {
 
 do_dns() {
   echo "Beginning action: DNS"
-  command="bash ${SCRIPT_BASE_DIR}/osc-dns-config -m=${MASTER} -n=${NODES} -b=${OPENSHIFT_BASE_DOMAIN} -d=${NODES##*,} -w=${NODES%%,*} -p=${OPENSHIFT_CLOUDAPPS_SUBDOMAIN}"
+  command="bash ${SCRIPT_BASE_DIR}/osc-dns-config -m=${MASTER} -e=${ETCD} -n=${NODES} -b=${OPENSHIFT_BASE_DOMAIN} -d=${NODES##*,} -w=${NODES%%,*} -p=${OPENSHIFT_CLOUDAPPS_SUBDOMAIN}"
   $command || error_out "DNS Install & Configuration failed." $ERROR_CODE_DNS_FAILURE
 }
 
@@ -182,6 +199,7 @@ do_install() {
   fi
 
   MASTER_HOSTNAME=$(get_hostnames $(get_private_ips "${MASTER}") "${OPENSHIFT_BASE_DOMAIN}")
+  ETCD_HOSTNAMES=$(get_hostnames $(get_private_ips "${ETCD}") "${OPENSHIFT_BASE_DOMAIN}")
   NODE_HOSTNAMES=$(get_hostnames $(get_private_ips "${NODES}") "${OPENSHIFT_BASE_DOMAIN}")
 
   echo "Install"
@@ -209,7 +227,7 @@ do_post(){
   ### Workarounds for current issues - START
 
   # Remove --insecure-registry flag set by ansible (https://github.com/openshift/openshift-ansible/issues/497)
-  for node in ${NODE_HOSTNAMES//,/ }; do
+  for node in ${NODE_HOSTNAMES//,/ } ${ETCD_HOSTNAMES//,/ }; do
     $SSH_CMD $node 'sed -i "s/--insecure-registry=172.30.0.0\/16//" /etc/sysconfig/docker && systemctl restart docker'
   done
 
@@ -341,6 +359,9 @@ do
     -m=*|--master=*)
       MASTER="${i#*=}"
       shift;;
+    -e=*|--etcd=*)
+      ETCD="${i#*=}"
+      shift;;
     -n=*|--nodes=*)
       NODES="${i#*=}"
       shift;;
@@ -375,6 +396,7 @@ OPENSHIFT_STORAGE_SIZE_OSE=${CONF_STORAGE_SIZE_OSE:=$storage_size_ose}
 OPENSHIFT_STORAGE_SIZE_ETCD=${CONF_STORAGE_SIZE_ETCD:=$storage_size_etcd}
 OPENSHIFT_STORAGE_SIZE_LOGGING=${CONF_STORAGE_SIZE_LOGGING:=$storage_size_logging}
 OPENSHIFT_IDENTITY_PROVIDER_JSON="${CONF_OPENSHIFT_IDENTITY_PROVIDER_JSON:=$openshift_identity_provider_json}"
+#OPENSHIFT_ETCD_ON_MASTER=${CONF_OPENSHIFT_ETCD_ON_MASTER:=$etcd_on_master}
 
 # Begin installation phases
 process_actions ${ACTIONS?"Missing argument -a or --action"}

--- a/provisioning/osc-provision
+++ b/provisioning/osc-provision
@@ -35,7 +35,8 @@ usage() {
   Usage: $0 [options]
 
   Options:
-  --num-nodes=<integer>         : Number of Nodes to provision
+  --num-nodes=<integer>         : Number of node instances to provision
+  --num-etcd=<integer>          : Number of etcd instances to provision
   --config=<path>               : Path to a config file for defining the environment
   --no-install                  : Provision instances and sync keys, but do not run the OpenShift installer
   --keep-util-host              : Keep Utility Host around after the execution has completed
@@ -89,7 +90,6 @@ install_cicd() {
       sync_files "${CONF_CICD_NEXUS_CONFIG_FILES//,/ }" "${cicd_public}"
   fi
 
-
   # Copy Java Certificates Files
   if [ -n "${CONF_JAVA_CERTS}" ]; then
 	  sync_files "${CONF_JAVA_CERTS//,/ }" "${cicd_public}"
@@ -115,7 +115,7 @@ install_openshift() {
   ${SSH_CMD} root@${utility_public} "awk -F'=' '/${OPENSHIFT_NODE_SERVICE}/ {print \"openshift_node_service=\"\$2}' ~/${REPO_BASE_NAME}/provisioning/lib/constants >> ~/${REPO_BASE_NAME}/provisioning/lib/constants"
   ${SSH_CMD} root@${utility_public} "awk -F'=' '/${OPENSHIFT_IDENTITY_PROVIDER_JSON}/ {print \"openshift_identity_provider_json=\"\$2}' ~/${REPO_BASE_NAME}/provisioning/lib/constants >> ~/${REPO_BASE_NAME}/provisioning/lib/constants"
 
-  ${SSH_CMD} root@${utility_public} "$CONF_ENVIRONMENT bash${bash_opts} ~/${REPO_BASE_NAME}/provisioning/osc-install -m='${master_ip}' -n='${node_ips//$'\n'/,}' -a='prep,dns,install,post'"
+  ${SSH_CMD} root@${utility_public} "$CONF_ENVIRONMENT bash${bash_opts} ~/${REPO_BASE_NAME}/provisioning/osc-install -m='${master_ip}' -e='${etcd_ips//$'\n'/,}' -n='${node_ips//$'\n'/,}' -a='prep,dns,install,post'"
 }
 
 random_string() {
@@ -137,12 +137,11 @@ provision_cicd() {
   fi
 
   FINAL_OUTPUT="CICD Server: $cicd_ip"
-
 }
 
 provision_openshift() {
   if [ -z $num_of_nodes ]; then
-    echo "Missing argument: --num-nodes <integer>"
+    echo "Missing argument: --num-nodes=<integer>"
     usage
     exit 1;
   fi
@@ -154,16 +153,28 @@ provision_openshift() {
   echo "Provisioning master. This could take several minutes."
   master_ip=$(provision_masters) || error_out "Provisioning Failed." $ERROR_CODE_PROVISION_FAILURE
   echo "Complete!"
+  if $etcd_on_master; then
+    num_etcd_instances=$(( $num_of_etcd-1 ))
+  else
+    num_etcd_instances=${num_of_etcd}
+    echo "etcd will NOT be on master"
+  fi
+  if [[ $num_etcd_instances > 0 ]]; then
+    echo "Provisioning $num_etcd_instances etcd. This could take several minutes."
+    etcd_ips=$(provision_etcds) || error_out "Provisioning Failed." $ERROR_CODE_PROVISION_FAILURE
+    echo "Complete!"
+  fi
   echo "Provisioning $num_of_nodes nodes. This could take several minutes."
   node_ips=$(provision_nodes) || error_out "Provisioning Failed." $ERROR_CODE_PROVISION_FAILURE
   echo "Complete!"
 
   utility_public=$(get_public_ips "${utility_ip}")
   master_public=$(get_public_ips "${master_ip}")
+  etcd_publics=$(get_public_ips "${etcd_ips//$'\n'/,}")
   node_publics=$(get_public_ips "${node_ips//$'\n'/,}")
 
   # Sync SSH keys
-  ${SCRIPT_BASE_DIR}/osc-sync-keys -m="${utility_public}" -n="${master_public},${node_publics}"
+  ${SCRIPT_BASE_DIR}/osc-sync-keys -m="${utility_public}" -e="${etcd_publics}" -n="${master_public},${node_publics}"
   [ $? -eq 0 ] || error_out "Key Sync Failed."
 
   if $master_is_node; then
@@ -174,6 +185,10 @@ provision_openshift() {
   # Sync user file to instances
   if [ -n "${OPENSHIFT_MASTER_FILES}" ]; then
     sync_files "${OPENSHIFT_MASTER_FILES}" "${master_public}"
+  fi
+
+  if [ -n "${OPENSHIFT_ETCD_FILES}" ]; then
+    sync_files "${OPENSHIFT_ETCD_FILES}" "${etcd_publics}"
   fi
 
   if [ -n "${OPENSHIFT_NODE_FILES}"]; then
@@ -198,6 +213,14 @@ provision_openshift() {
 Master:
   - Hostname: $( get_hostnames $master_public $OPENSHIFT_BASE_DOMAIN $dns_server)
   - IPs: ${master_ip}
+Etcd: "
+  for etcd in ${etcd_ips//$'\n'/ }; do
+    FINAL_OUTPUT="${FINAL_OUTPUT}
+  - Etcd
+  -- Hostname: $(get_hostnames $(get_public_ips ${etcd}) $OPENSHIFT_BASE_DOMAIN $dns_server)
+  -- IPs: ${etcd}"
+  done
+  FINAL_OUTPUT="${FINAL_OUTPUT}
 Nodes: "
   for node in ${node_ips//$'\n'/ }; do
     FINAL_OUTPUT="${FINAL_OUTPUT}
@@ -249,6 +272,21 @@ provision_masters() {
   $command || error_out "Master Provision failed. See log at ${LOGFILE}." ${ERROR_CODE_PROVISION_FAILURE}
 }
 
+provision_etcds() {
+  instance_name="etcd-${ENV_ID}"
+  command="${SCRIPT_BASE_DIR}/${platform}/provision.sh \
+  --instance-name ${instance_name} \
+  --key ${key} \
+  --flavor ${OS_FLAVOR} \
+  --image-name ${IMAGE_NAME} \
+  --security-groups ${SECURITY_GROUP_MASTER} \
+  --num-instances $num_etcd_instances \
+  --add-volume ${VOLUME_SIZE} \
+  --n \
+  --debug"
+  $command || error_out "Etcd Provision failed. See log at ${LOGFILE}." ${ERROR_CODE_PROVISION_FAILURE}
+}
+
 provision_nodes() {
   instance_name="node-${ENV_ID}"
   command="${SCRIPT_BASE_DIR}/${platform}/provision.sh \
@@ -272,6 +310,9 @@ do
   case $i in
     --num-nodes=*)
       num_of_nodes="${i#*=}"
+      shift;;
+    --num-etcd=*)
+      num_of_etcd="${i#*=}"
       shift;;
     --config=*)
       process_configfile "${i#*=}"
@@ -320,8 +361,10 @@ OS_FLAVOR=${CONF_OS_FLAVOR:-$os_flavor}
 PROVISION_COMPONENTS=${CONF_PROVISION_COMPONENTS:-$provision_components}
 VOLUME_SIZE=${CONF_VOLUME_SIZE:-$storage_volume_size}
 OPENSHIFT_MASTER_FILES="${CONF_OPENSHIFT_MASTER_FILES}"
+OPENSHIFT_ETCD_FILES="${CONF_OPENSHIFT_ETCD_FILES}"
 OPENSHIFT_NODE_FILES="${CONF_OPENSHIFT_NODE_FILES}"
 OPENSHIFT_VERSION="${CONF_OPENSHIFT_VERSION}"
+OPENSHIFT_ETCD_ON_MASTER=${CONF_OPENSHIFT_ETCD_ON_MASTER:-$etcd_on_master}
 
 # Determine version specific details...
 case $CONF_OPENSHIFT_VERSION in

--- a/provisioning/osc-sync-keys
+++ b/provisioning/osc-sync-keys
@@ -6,7 +6,7 @@ source ${SCRIPT_BASE_DIR}/lib/constants
 ## Functions
 
 usage() {
-  echo "Usage: $0 -m=|--master=\"<master hostname>\" -n=|--nodes=\"<node1 hostname>,..,<nodeN hostname>\""
+  echo "Usage: $0 -m=|--master=\"<master hostname>\" -e=|--etcd=\"<etcd1 hostname>,..,<etcdN hostname>\" -n=|--nodes=\"<node1 hostname>,..,<nodeN hostname>\""
 }
 
 for i in "$@"
@@ -14,6 +14,10 @@ do
 case $i in
   -m=*|--master=*)
     MASTER="${i#*=}"
+    shift
+    ;;
+  -e=*|--etcd=*)
+    ETCD="${i#*=}"
     shift
     ;;
   -n=*|--nodes=*)
@@ -48,7 +52,7 @@ $SSH_CMD root@${MASTER} 'mkdir -p ~/.ssh'
 echo "${public_key}" | $SSH_CMD root@${MASTER} 'cat  >> ~/.ssh/authorized_keys'
 $SSH_CMD root@${MASTER} 'chmod 700 ~/.ssh; chmod 600 ~/.ssh/*'
 
-for node in ${NODES//,/ }; do
+for node in ${NODES//,/ } ${ETCD//,/ }; do
   echo -n "Pushing key for node ${node}..."
   $SSH_CMD root@${node} 'mkdir -p ~/.ssh'
   echo "${public_key}" | $SSH_CMD root@${node} 'cat  >> ~/.ssh/authorized_keys'

--- a/provisioning/templates/ansible-hosts-ose3_0
+++ b/provisioning/templates/ansible-hosts-ose3_0
@@ -17,8 +17,10 @@ openshift_master_identity_providers=[{{OPENSHIFT_IDENTITY_PROVIDER_JSON}}]
 [masters]
 {{MASTER_HOSTNAME}} openshift_hostname={{MASTER_HOSTNAME}} openshift_public_hostname={{MASTER_HOSTNAME}} openshift_schedulable=True
 
+# host group for etcd
 [etcd]
 {{MASTER_HOSTNAME}}
+{{ETCDSTRING}}
 
 # host group for nodes
 [nodes]

--- a/provisioning/templates/ansible-hosts-ose3_1
+++ b/provisioning/templates/ansible-hosts-ose3_1
@@ -17,8 +17,10 @@ openshift_master_identity_providers=[{{OPENSHIFT_IDENTITY_PROVIDER_JSON}}]
 [masters]
 {{MASTER_HOSTNAME}} openshift_hostname={{MASTER_HOSTNAME}} openshift_public_hostname={{MASTER_HOSTNAME}} openshift_schedulable=True
 
+# host group for etcd
 [etcd]
 {{MASTER_HOSTNAME}}
+{{ETCDSTRING}}
 
 # host group for nodes
 [nodes]


### PR DESCRIPTION
#### What does this PR do?

This PR adds the ability to provision and configure high available etcd data stores for OpenShift.
#### How should this be manually tested?

Pull down updated branch to provision an OSE 3 environment with HA etcd using the following command:

```
./osc-provision --num-nodes=2 --num-etcd=3 --keep-util-host --key=<your-key> --ose-version=3.1
```

After installation, verify the OSE 3 install was successful. (see playbook for [validating the install](http://playbooks-rhtconsulting.rhcloud.com/playbooks/installation/install_validation.html)).  Additionally validate that the etcd data store cluster is healthy and verify member list using the following commands:

```
# etcdctl -C \
    https://master.ose.example.com:2379,https://etcd1.ose.example.com:2379,https://etcd2.ose.example.com:2379 \
    --ca-file=/etc/origin/master/master.etcd-ca.crt \
    --cert-file=/etc/origin/master/master.etcd-client.crt \
    --key-file=/etc/origin/master/master.etcd-client.key cluster-health

# etcdctl -C \
    https://master.ose.example.com:2379,https://etcd1.ose.example.com:2379,https://etcd2.ose.example.com:2379 \
    --ca-file=/etc/origin/master/master.etcd-ca.crt \
    --cert-file=/etc/origin/master/master.etcd-client.crt \
    --key-file=/etc/origin/master/master.etcd-client.key member list
```
#### Is there a relevant Issue open for this?

No Github issue, however there is a Trello card I am currently assigned to for this feature. 
#### Who would you like to review this?

/cc @etsauer @oybed @sabre1041 
