### PR TITLE
Upgrades jekyll asciidoc builder image

### DIFF
--- a/docker/jekyll-asciidoc-docker/Dockerfile
+++ b/docker/jekyll-asciidoc-docker/Dockerfile
@@ -15,15 +15,15 @@ ADD bin/start.sh /home/builder/
 RUN echo "export BUNDLE_PATH=/home/builder/bundle" >> /home/builder/.bash_profile; \
     ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''; \
     chown builder:builder /home/builder/start.sh; \
-    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh | bash; \
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh | bash; \
 	bash -c "source /root/.nvm/install.sh"; \
 	gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3; \
 	curl -sSL https://get.rvm.io | bash -s stable; \
 	source /etc/profile.d/rvm.sh;
 	
 RUN	/bin/bash -l -c "rvm requirements"; 
-RUN	/bin/bash -l -c "rvm install 2.2.1";
-RUN	/bin/bash -l -c "rvm use 2.2.1";
+RUN	/bin/bash -l -c "rvm install 2.3.0";
+RUN	/bin/bash -l -c "rvm use 2.3.0";
 RUN	/bin/bash -l -c "rvm rubygems latest";
 RUN /bin/bash -l -c "gem install bundler";
 

--- a/docker/jekyll-asciidoc-docker/bin/start.sh
+++ b/docker/jekyll-asciidoc-docker/bin/start.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
 SOURCE_DIR=/home/builder/source
+BUILD_DIR=/home/builder/build
 
 if [ ! -d "$SOURCE_DIR" ]; then
    echo "Error: Source volume not mounted or available"
    exit 1
 fi
 
-cd "$SOURCE_DIR"
+mkdir -p "${BUILD_DIR}"
+
+cp -a ${SOURCE_DIR}/. ${BUILD_DIR}
+
+cd "$BUILD_DIR"
 
 bundle install
 bundle exec jekyll serve --host=0.0.0.0


### PR DESCRIPTION
#### What does this PR do?

Upgrade Ruby versions in `jekyll-asciidoc-docker` image along with copying content to build directory in container to ensure source content is untouched by build process
#### How should this be manually tested?

Pull down changes from this PR

Rebuild image and run

```
./run.sh --directory=<directory_with_content> --rebuild
```
#### Is there a relevant Issue open for this?

No
#### Who would you like to review this?

/cc @etsauer @oybed @JaredBurck 
