### PR TITLE
Updated base image to exclude docker 1.9 due to OSEv3.1 issues with 1.9

### DIFF
--- a/provisioning/openstack/tailor_image_ose31
+++ b/provisioning/openstack/tailor_image_ose31
@@ -108,6 +108,7 @@ function _updateRHSubscription()
 
 function _updateSoftware()
 {
+  sed -i "s/\[main\]/[main]\nexclude=docker-1.9* docker-selinux-1.9*/" /etc/yum.conf
   yum clean all
   yum install -y wget git net-tools bind-utils iptables-services bridge-utils bash-completion rsync lvm2 
   yum update -y


### PR DESCRIPTION
#### What does this PR do?

Excludes docker 1.9 to work around issues with current repos
#### How should this be manually tested?

Create a new base image, for example:

```
./create_base_image -k=<key> -v=3.1
```

Then use the resulting image in a deployment by specify the CONF_IMAGE_NAME in a custom configuration file.
#### Is there a relevant Issue open for this?

N/A
#### Who would you like to review this?

/cc @etsauer 
