### PR TITLE
Change default_env_id of "testenv" to local env OS_USERNAME

### DIFF
--- a/rhc-ose-ansible/roles/common/defaults/main.yml
+++ b/rhc-ose-ansible/roles/common/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-default_env_id: "{{ lookup('env','OS_USERNAME') }}"
+default_env_id: "casl-{{ lookup('env','OS_USERNAME') }}"

--- a/rhc-ose-ansible/roles/common/defaults/main.yml
+++ b/rhc-ose-ansible/roles/common/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-default_env_id: "testenv"
+default_env_id: "{{ lookup('env','OS_USERNAME') }}"


### PR DESCRIPTION
#### What does this PR do?

Changes the default for the **default_env_id** variable to use the local system's **OS_USERNAME** variable that should be sourced from a file similar to **openrc.sh**.
#### How should this be manually tested?

Run a playbook and do not specify the **env_id** variable so the default can be used. Verify the name contains your OpenStack username.
#### Is there a relevant Issue open for this?

None.
#### Who would you like to review this?

/cc @oybed @etsauer @sabre1041 
