### PR TITLE
Reorder instances names to sort by env_id

### DIFF
--- a/rhc-ose-ansible/roles/openstack-create/tasks/main.yml
+++ b/rhc-ose-ansible/roles/openstack-create/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: "Provision OpenStack {{ type }}"
   nova_compute:
-    name: "{{ type }}{{ item }}-{{ env_id }}"
+    name: "{{ env_id }}-{{ type }}{{ item }}"
     state: present
     image_name: "{{ image_name }}"
     flavor_id: "{{ flavor_id }}"


### PR DESCRIPTION
#### What does this PR do?

This PR changes the instance name to put **env_id** before **type**.Currently the **type** comes before the **env_id** so when several environments exist they are grouped/sorted by **type** rather than **env_id**. Essentially this changes the naming from most specific first to least specific first in order to group similar environments together.

This applies to **nova list** or the Horizon web UI. By default instances are sorted by **uptime** in the Horizon UI, but if **Instance Name** is clicked to sort, it will sort alphabetically by name just like **nova list** on the CLI does.

Here is output of **nova list** before this PR (only showing the **Name** column for readability, but this is the default sorting order):

```
master1-vvaldez-ai0Zb2wz
master1-vvaldez-bgKBSRLt
master1-vvaldez-vPm3EkyH
node1-vvaldez-ai0Zb2wz
node1-vvaldez-bgKBSRLt
node1-vvaldez-vPm3EkyH
node2-vvaldez-ai0Zb2wz
node2-vvaldez-bgKBSRLt
node2-vvaldez-vPm3EkyH
```

After this PR:

```
vvaldez-gDjBm7f1-master1
vvaldez-gDjBm7f1-node1
vvaldez-gDjBm7f1-node2
vvaldez-rafVkEtG-master1
vvaldez-rafVkEtG-node1
vvaldez-rafVkEtG-node2
vvaldez-uOEHIpUM-master1
vvaldez-uOEHIpUM-node1
vvaldez-uOEHIpUM-node2
```
#### How should this be manually tested?

Provision several environments and do not specify a **env_id**
#### Is there a relevant Issue open for this?

None.
#### Who would you like to review this?

/cc @oybed @etsauer @sabre1041 
