### PR TITLE
Add docker role

### DIFF
--- a/rhc-ose-ansible/ose-provision.yml
+++ b/rhc-ose-ansible/ose-provision.yml
@@ -38,3 +38,4 @@
   roles:
     - { role: subscription-manager, when: hostvars.localhost.rhsm_register, tags: 'subscription-manager', ansible_sudo: true }
     - openshift-provision
+    - { role: docker, tags: 'docker' }

--- a/rhc-ose-ansible/roles/docker/defaults/main.yml
+++ b/rhc-ose-ansible/roles/docker/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+default_docker_storage_block_device: "/dev/vdb"
+default_docker_storage_volume_group: "docker_vg"

--- a/rhc-ose-ansible/roles/docker/handlers/main.yml
+++ b/rhc-ose-ansible/roles/docker/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: enable docker
+  service: 
+    name: docker
+    enabled: yes
+
+- name: restart docker
+  service:
+    name: docker
+    enabled: yes
+    state: restarted

--- a/rhc-ose-ansible/roles/docker/tasks/main.yml
+++ b/rhc-ose-ansible/roles/docker/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+- name: "Setting Docker Facts"
+  set_fact:
+    docker_storage_block_device: "{{ docker_storage_block_device | default(default_docker_storage_block_device) }}"
+    docker_storage_volume_group: "{{ docker_storage_volume_group | default(default_docker_storage_volume_group) }}"
+
+- name: "Install Docker"
+  yum: 
+    name: docker
+    state: latest
+  notify:
+    - enable docker
+
+- name: "Confige Docker"
+  lineinfile: 
+    dest: /etc/sysconfig/docker 
+    regexp: '^OPTIONS=.*$' 
+    line: "^OPTIONS='--selinux-enabled --insecure-registry 172.30.0.0/16'"
+
+- name: "Check for existing Docker Storage device"
+  command: pvs
+  register: pvs
+
+- name: "Set Docker Storage fact if already configured"
+  set_fact:
+    docker_storage_setup: true
+  when: pvs.stdout | search('{{ docker_storage_block_device }}.*{{ docker_storage_volume_group }}')
+
+- name: "Configure Docker Storage Setup"
+  template:
+    src: docker-storage-setup.j2
+    dest: /etc/sysconfig/docker-storage-setup
+  when: docker_storage_setup is undefined
+  
+- name: "Run Docker Storage Setup"
+  command: docker-storage-setup
+  when: docker_storage_setup is undefined
+  notify:
+  - restart docker
+
+- name: "Extend the Volume Group for Docker Storage"
+  command: lvextend -l 90%VG /dev/{{ docker_storage_volume_group }}/docker-pool
+  when: docker_storage_setup is undefined
+  notify:
+  - restart docker

--- a/rhc-ose-ansible/roles/docker/templates/docker-storage-setup.j2
+++ b/rhc-ose-ansible/roles/docker/templates/docker-storage-setup.j2
@@ -1,0 +1,2 @@
+DEVS={{ docker_storage_block_device }}
+VG={{ docker_storage_volume_group }}


### PR DESCRIPTION
#### What does this PR do?

Adds Ansible role for Docker. Largely taken from **cicd docker.yml** with a few changes. Changed docker-storage-setup file to use a template and referred to defined variables for DEV and VG which follow the other roles in this repo with defaults set. Each instance uses the output of **pvs** to determine if the DEV and VG are already in use, in which case it will skip docker-storage-setup steps.
#### How should this be manually tested?

Provision an environment and include this role. The PR includes a reference to this role in **ose-provision.yml**
#### Is there a relevant Issue open for this?

None.
#### Who would you like to review this?

/cc @oybed @etsauer @sabre1041 
