### PR TITLE
Add connection test to OpenStack before proceeding

### DIFF
--- a/rhc-ose-ansible/roles/openstack-create/pre_tasks/pre_tasks.yml
+++ b/rhc-ose-ansible/roles/openstack-create/pre_tasks/pre_tasks.yml
@@ -1,4 +1,9 @@
 ---
-- name: Validate OpenStack SSH key is defined
+- name: "Validate OpenStack SSH key is defined"
   fail: msg="Required 'openstack_key_name' is not defined!"
   when: openstack_key_name is undefined or openstack_key_name is none or openstack_key_name|trim == ''
+
+- name: "Verify connectivity to OpenStack"
+  command: "nova credentials"
+  register: nova_result
+  failed_when: nova_result.rc != 0


### PR DESCRIPTION
#### What does this PR do?

Adds a connection check task using **nova credentials** to pre_tasks to abort the playbook if a connection to the specified OpenStack environment is not present before getting too far in the playbook. This could be due the openrc.sh file not being sourced, bad information sourced, a connection to the environment is down (such as any required VPN not connected), or other network problems.

Note that the output of **nova credentials** only contains the user and tenant ids and the user role, no sensitive authentication data, but this would only be shown with **-v**. A normal playbook run only shows the task name.
- Sample playbook run success:
  
  ```
  TASK: [Verify connectivity to OpenStack] ************************************** 
  changed: [localhost]
  ```
- Sample playbook run failure:
  
  ```
  TASK: [Verify connectivity to OpenStack] ************************************** 
  failed: [localhost] => {"changed": true, "cmd": ["nova", "credentials"], "delta": "0:00:25.645991", "end": "2016-04-09 19:16:20.299660", "failed": true, "failed_when_result": true, "rc": 1, "start": "2016-04-09 19:15:54.653669", "stdout_lines": [], "warnings": []}
  stderr: No handlers could be found for logger "keystoneclient.auth.identity.generic.base"
  ERROR (ConnectionRefused): Unable to establish connection to http://openstack.example.com:5000/v2.0/tokens
  
  FATAL: all hosts have already failed -- aborting
  ```
#### How should this be manually tested?

Run a playbook that uses the **openstack-create** role **pre_tasks** section with any of the following conditions:
- Unload any OpenStack environment variables
- Deliberately source incorrect data such as endpoints, username or password for the OpenStack environment
- Disconnect any required VPN connections or shutdown network interface
#### Is there a relevant Issue open for this?

None.
#### Who would you like to review this?

/cc @oybed @etsauer @sabre1041 
