### PR TITLE
initial addition of pre-installation verification scripts

### DIFF
--- a/ose_verification/helper_functions.py
+++ b/ose_verification/helper_functions.py
@@ -1,0 +1,23 @@
+# Owner: Steve Ovens
+# Date Created: Aug 2015
+# Primary Function: This is a file intended to be supporting functions in various scripts
+# This file will do nothing if run directly
+
+import sys
+
+
+class ImportHelper:
+
+    """ This class simply allows for the dynamic loading of modules which are not apart of the stdlib.
+     It specifies which module cannot be imported and provides the proper pip install command as output to the user.
+    """
+
+    @staticmethod
+    def import_error_handling(import_this_module, modulescope):
+        try:
+            exec("import %s " % import_this_module) in modulescope
+        except ImportError:
+            print("This program requires %s in order to run. Please run" % import_this_module)
+            print("pip install %s" % import_this_module)
+            print("To install the missing component")
+            sys.exit()

--- a/ose_verification/ssh_connection_handling.py
+++ b/ose_verification/ssh_connection_handling.py
@@ -1,0 +1,36 @@
+# Owner: Steve Ovens
+# Date Created: July 2015
+# Primary Function: This is an ssh connection handler to be imported by any script requiring remote access.
+# It will do nothing if called directly.
+# Dependencies: helper_functions.py
+
+class HandleSSHConnections:
+    """This class allows for easier multiple connections. The problem is because /etc/init.d/tomcat restart
+    Sometimes does not wait long enough between stop and start functions. As a result, tomcat may stay down
+    To remedy this, this class will open multiple connections inserting a 20 second pause between connections
+    Hopefully this will allow most instances of tomcat to shutdown gracefully before restarting """
+    from helper_functions import ImportHelper
+    ImportHelper.import_error_handling("paramiko", globals())
+    ImportHelper.import_error_handling("time", globals())
+
+    def open_ssh(self, server, user_name):
+        if not self.ssh_is_connected():
+            self.ssh = paramiko.SSHClient()
+            self.ssh.load_system_host_keys()
+            self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            self.ssh.connect(server, username=user_name, timeout=120)
+            self.transport = self.ssh.get_transport()
+            self.psuedo_tty = self.transport.open_session()
+            self.psuedo_tty.get_pty()
+            self.read_tty = self.psuedo_tty.makefile()
+
+    def close_ssh(self):
+        if self.ssh_is_connected():
+            self.read_tty.close()
+            self.psuedo_tty.close()
+            self.ssh.close()
+            time.sleep(2)
+
+    def ssh_is_connected(self):
+        transport = self._ssh.get_transport() if self._ssh else None
+        return transport and transport.is_active()

--- a/ose_verification/validate_ose_pre_install.py
+++ b/ose_verification/validate_ose_pre_install.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python2
+
+import socket
+from helper_functions import ImportHelper
+from deployment_parameters import ParseDeploymentParameters
+from ssh_connection_handling import HandleSSHConnections
+ImportHelper.import_error_handling("paramiko", globals())
+import hashlib
+
+docker_file_dict = {}
+forward_lookup_dict = {}
+reverse_lookup_dict = {}
+ssh_connection = HandleSSHConnections()
+
+
+def add_to_dictionary(dictionary, name_of_server, component, value):
+    if name_of_server in dictionary:
+        dictionary[name_of_server][component] = value
+    else:
+        dictionary[name_of_server] = {component:value}
+
+
+def process_host_file(ansible_host_file):
+    # This section should parse the ansible host file for hosts
+    # This doesn't work as it stands because it will suck in variables from the OSE install as well
+    # Need a better way to parse the config file
+
+    hosts_list = []
+    for line in open(ansible_host_file).readlines():
+        if line.startswith("["):
+            pass
+        else:
+            host = line.split()[0]
+            hosts_list.append(host)
+
+
+def test_ssh_keys(host, user):
+    """
+    test_ssh_keys simply attempts to open an ssh connection to the host
+    returns True if the connection throws a Paramiko exception
+    """
+    try:
+        ssh_connection.open_ssh(host, user)
+        ssh_connection.close_ssh()
+        ssh_connection_failed = False
+    except paramiko.ssh_exception.AuthenticationException:
+        ssh_connection_failed = True
+
+    return(ssh_connection_failed)
+
+
+def check_forward_dns_lookup(host_name):
+    """
+    uses socket to do a forward lookup on host
+    returns lookup_passed (True|False) and the host_ip
+    """
+    try:
+        host_ip = socket.gethostbyname(host_name)
+        lookup_passwed = True
+    except socket.gaierror:
+        try:
+            socket.inet_aton(host_name)
+            print("You should be using FQDN instead of IPs in your ansible host file!")
+            pass
+        except socket.error:
+            pass
+        lookup_passed = False
+        host_ip = ""
+
+    return(lookup_passed, host_ip)
+
+
+def check_reverse_dns_lookup(lookup_dict):
+    """
+    uses socket to do a reverse lookup on hosts in forward_lookup_dict
+    returns lookup_passed (True|False) and the hostname
+    """
+    for hostname in lookup_dict.keys():
+        host_ip = lookup_dict[hostname]["ip"]
+        try:
+            hostname = socket.gethostbyaddr(host_ip)
+            lookup_passed = True
+        except socket.herror:
+            lookup_passed = False
+            hostname = ""
+
+    return(lookup_passed, hostname)
+
+
+def check_docker_files(host, ssh_user):
+    """
+    check_docker_files assumes there is already a paramiko connection made to the server in question
+    """
+    file_list = ["/etc/sysconfig/docker", "/etc/sysconfig/docker-storage", "/ect/sysconfig/docker-storage-setup"]
+    for files in file_list:
+        try:
+            ssh_connection.open_ssh(host, ssh_user)
+            stdin, stdout, stderr = ssh_connection.ssh.exec_command("sha256sum %s" % files)
+            for line in stdout.channel.recv(1024).split("\n"):
+                if line.strip():
+                    add_to_dictionary(docker_file_dict, host, files, line.split()[0])
+        except socket.error:
+            print("No SSH connection is open")
+
+# check if docker service is enabled
+
+
+# check if docker service is started
+
+
+# check if hosts are subscribed
+
+
+# check if proper repos are enabled
+
+
+# check that proper yum packages are installed


### PR DESCRIPTION
#### What does this PR do?

This pull request adds 2 class files and one executable script which test for the following
- tests to ensure ssh keys exist from ansible host to all OSE hosts in the ansible host file
- checks to see if SELinux is enabled
- checks forward and reverse dns lookups
- checks to see if the docker files have been modified from their defaults
- checks to see if docker is enabled and running
- checks to see if the host is properly subscribed
- ensures the correct repos are available
- checks to see that all of the OSE required packages are installed
- checks to see if there are updates available in general for the system
#### How should this be manually tested?

It has standard python usage help

```
[root@lb00 OSE_Setup]# time ./validate_ose.py -h
Usage: validate_ose.py [options]

Options:
  -h, --help            show this help message and exit
  --ansible-host-file=ANSIBLE_HOST_FILE
                        Specify location of ansible hostfile
  --show-sha-sums=SHOW_SHA_SUMS
                        Toggle whether or not to show the sha sum of fileson
                        remote host
```

This script is an audit only and will not do any changes on its own. It can be
run like so:

```
./validate_ose.py --ansible-host-file ~/working_ansible --show-sha-sums yes
```

show_shaw_sums is optional and can be omitted. ansible-host-file is required
and the script will terminate if no host file is specified. 

The script uses the following colourization schemes for more readable output.

```
HEADER = '\033[95m'   # Purple
OKBLUE = '\033[94m'   # Blue
OKGREEN = '\033[92m'  # Green
WARNING = '\033[93m'  # Yellow
FAIL = '\033[91m'     # Red
ENDC = '\033[0m'      # Ends special colourization
BOLD = '\033[1m'      # makes text bold
UNDERLINE = '\033[4m' # currently not implemented
HIGHLIGHT = '\033[96m'# currently not implemented
```

The script expects to parse an ansible host file or a text file with a list
of fqdns

Sample output:
![](http://i57.photobucket.com/albums/g239/Stratus_ss/ose_validation1_zpst1i5izkd.png)
![](http://i57.photobucket.com/albums/g239/Stratus_ss/ose_validation2_zpsmcsotmfd.png)
#### Is there a relevant Issue open for this?

Open trello card: https://trello.com/c/ZzI1p8bN
#### Who would you like to review this?

/cc @etsauer @JaredBurck
