### PR TITLE
Add org parameter to Satellite with user/pass

### DIFF
--- a/rhc-ose-ansible/roles/subscription-manager/tasks/main.yml
+++ b/rhc-ose-ansible/roles/subscription-manager/tasks/main.yml
@@ -77,6 +77,18 @@
   when:
     - not registered
     - rhsm_authentication == "password"
+    - rhsm_org is not defined or rhsm_org is none or rhsm_org|trim == ''
+
+# This can apply to either Hosted or Satellite
+- name: "Register using username, password and organization"
+  command: "/usr/bin/subscription-manager register --username={{ rhsm_username }} --password={{ rhsm_password }} --org={{ rhsm_org }}"
+  no_log: true
+  when:
+    - not registered
+    - rhsm_authentication == "password"
+    - rhsm_org is defined
+    - rhsm_org is not none
+    - rhsm_org|trim != ''
 
 - name: "Auto-attach to Subscription Manager Pool"
   command: "/usr/bin/subscription-manager attach --auto"


### PR DESCRIPTION
#### What does this PR do?

Adds the ability to specify an organization when registering using username and password. PR #133 assumed that the organization would be specified when using an activationkey, but if using Satellite and there are multiple orgs then a explicit org must be specified.
#### How should this be manually tested?

Specify the variables **rhsm_username** **rhsm_password**, **rhsm_org** and **rhsm_satellite**
#### Is there a relevant Issue open for this?

N/A
#### Who would you like to review this?

/cc @etsauer @sabre1041 @oybed 
