### PR TITLE
updated epel url from 7.5 to 7.6 and removed extra install

### DIFF
--- a/provisioning/cicd-install
+++ b/provisioning/cicd-install
@@ -72,10 +72,10 @@ function check_prereqs() {
 function install_prereqs() {
 	
 	# EPEL and software packages	
-	yum install -y install http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm wget firewalld unzip git vim &>/dev/null || error_out "Failed to install initial prerequisite software" 2
+	yum install -y http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm wget firewalld unzip git vim &>/dev/null || error_out "Failed to install initial prerequisite software" 2
 
 	# JQ must be installed only after EPEL installed
-	yum install -y install jq &>/dev/null || error_out "Failed to install jq" 2
+	yum install -y jq &>/dev/null || error_out "Failed to install jq" 2
 	
 	# Configure Firewall
 	systemctl disable iptables


### PR DESCRIPTION
#### What does this PR do?

This PR fixes the error "Failed to install jq".  This was caused by epel 7.5 release is not found and the current epel release version is 7.6.  The epel URL in the yum command has been updated to reflect this change by updating the version.

Removed the second install in yum commands; from `yum install -y install` to `yum install -y`. 

Alternatively, the epel URL could use the latest [1] instead of the version [2] release, just a thought.
NOTE [3] - You need to also enable the 'optional' repository to use EPEL packages as they depend on packages in that repository. For EPEL 7, in addition to the 'optional' repository (rhel-7-server-optional-rpms), you also need to enable the 'extras' repository (rhel-7-server-extras-rpms).

[1] https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
[2] http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
[3] https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F
#### How should this be manually tested?

provision new cicd server environment and verify all software is installed and working correctly.

```
./osc-provision --config=sample.cfg --key=<key-name> --ose-version=3.1
```

sample.cfg

```
## OpenShift Configs
CONF_PROVISION_COMPONENTS=cicd # Comman separated list. Supported values are: openshift,cicd. Default: openshift
```

Verify all software is installed and working correctly and that you can navigate to Jenkins and Nexus.
#### Is there a relevant Issue open for this?

no
#### Who would you like to review this?

/cc @sabre1041  @etsauer 
