### PR TITLE
Role for disconnected git server

### DIFF
--- a/rhc-ose-ansible/inventory/disconnected-git
+++ b/rhc-ose-ansible/inventory/disconnected-git
@@ -1,0 +1,5 @@
+[disconnected-git]
+# Enter Address of Server
+
+[disconnected-git:vars]
+git_user_authorized_keys='["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQDH24TWdxAT8A5X+gbZHa3JgwGpGzx4VYRrvFaAcAKm0QrOYRdtO0+ioQFDkhUrzEOSIafNBeNxPhGl1AgH/cut4Nfr+i78q1cvglSuMx/Ac68/5LdLiyKd5zl2/DwshoKwotRhqm0ltURxEhWi0Ow6D+7OYbBQf7z2jbK8zFXcnQ== developer@redhat.com"]'

--- a/rhc-ose-ansible/roles/disconnected-git/defaults/main.yaml
+++ b/rhc-ose-ansible/roles/disconnected-git/defaults/main.yaml
@@ -1,0 +1,15 @@
+---
+git_repo_home: "/opt/git"
+ose_git_repo_home: "{{ git_repo_home }}/openshift"
+git_user: "git"
+
+# List of Authorized Keys to Add
+git_user_authorized_keys:
+
+ose_example_repos:
+ - "https://github.com/openshift/cakephp-ex.git"
+ - "https://github.com/openshift/dancer-ex.git"
+ - "https://github.com/jboss-openshift/openshift-quickstarts.git"
+ - "https://github.com/openshift/django-ex.git"
+ - "https://github.com/openshift/nodejs-ex.git"
+ - "https://github.com/openshift/rails-ex.git"

--- a/rhc-ose-ansible/roles/disconnected-git/handlers/main.yaml
+++ b/rhc-ose-ansible/roles/disconnected-git/handlers/main.yaml
@@ -1,0 +1,6 @@
+---
+
+- name: restart httpd
+  service: 
+    name: httpd
+    state: restarted

--- a/rhc-ose-ansible/roles/disconnected-git/tasks/main.yaml
+++ b/rhc-ose-ansible/roles/disconnected-git/tasks/main.yaml
@@ -1,0 +1,65 @@
+---
+- name: Install Packages
+  action: "{{ ansible_pkg_mgr }} name={{ item }} state=present"
+  with_items:
+    - git
+    - httpd
+    - firewalld
+    
+- name: Create Git User
+  user: name="{{ git_user }}"
+
+- name: Create Git User Authorized Keys
+  authorized_key:
+    user: "{{ git_user}}"
+    key: "{{ item }}"
+  with_items:
+    - "{{ git_user_authorized_keys }}"
+  
+- name: Create OSE Git Repository Content Home
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ git_user }}"
+    group: "{{ git_user }}"
+  with_items:
+    - "{{ git_repo_home }}"
+    - "{{ ose_git_repo_home }}"
+
+- name: Close OSE Examples
+  git:
+    repo: "{{ item }}"
+    bare: yes
+    dest: "{{ ose_git_repo_home }}/{{ item | basename }}"
+  with_items:
+    - "{{ ose_example_repos }}"
+  tags: test
+  become: yes
+  become_user: "{{ git_user }}"
+  
+- name: Configure Git HTTP Configuration
+  template:
+    src: "{{ role_path }}/templates/git.conf.j2"
+    dest: "/etc/httpd/conf.d/git.conf"
+    owner: root
+    group: root
+  notify: restart httpd
+
+- name: Enable Services
+  service: name={{ item }} enabled=yes state=started   
+  with_items:
+    - firewalld
+    - httpd 
+    
+- name: HTTPD SELinux Configurations
+  seboolean: 
+    name: httpd_can_network_connect
+    state: yes
+    persistent: yes
+
+- name: Open Firewall for HTTPD
+  firewalld: port=80/tcp permanent=yes state=enabled immediate=yes zone=public
+  
+
+
+  

--- a/rhc-ose-ansible/roles/disconnected-git/tasks/main.yaml
+++ b/rhc-ose-ansible/roles/disconnected-git/tasks/main.yaml
@@ -5,6 +5,7 @@
     - git
     - httpd
     - firewalld
+    - libsemanage-python
     
 - name: Create Git User
   user: name="{{ git_user }}"
@@ -26,7 +27,7 @@
     - "{{ git_repo_home }}"
     - "{{ ose_git_repo_home }}"
 
-- name: Close OSE Examples
+- name: Clone OSE Examples
   git:
     repo: "{{ item }}"
     bare: yes

--- a/rhc-ose-ansible/roles/disconnected-git/templates/git.conf.j2
+++ b/rhc-ose-ansible/roles/disconnected-git/templates/git.conf.j2
@@ -1,0 +1,26 @@
+<VirtualHost *:80>
+
+  SetEnv GIT_PROJECT_ROOT {{git_repo_home}}
+  SetEnv GIT_HTTP_EXPORT_ALL
+  SetEnv REMOTE_USER=$REDIRECT_REMOTE_USER
+  AliasMatch ^/git/(.*/objects/[0-9a-f]{2}/[0-9a-f]{38})$          {{git_repo_home}}/$1
+  AliasMatch ^/git/(.*/objects/pack/pack-[0-9a-f]{40}.(pack|idx))$ {{git_repo_home}}/$1
+  ScriptAliasMatch \
+       "(?x)^/git/(.*/(HEAD | \
+		       info/refs | \
+		       objects/info/[^/]+ | \
+		       git-(upload|receive)-pack))$" \
+       /usr/libexec/git-core/git-http-backend/$1
+
+  <Location /git/>
+    Options +ExecCGI +FollowSymLinks
+    Require all granted
+  </Location>
+
+
+  <Directory />
+    Options FollowSymLinks
+    AllowOverride None
+  </Directory>
+
+</VirtualHost>


### PR DESCRIPTION
#### What does this PR do?

Support for a git server to host OpenShift example content in a disconnected environment
#### How should this be manually tested?
- Create a new server instance
- Create an _inventory_ file in the inventory folder with the following content with the name `disconnected-git`

```
[disconnected-git]
<server_ip>
```
- Create a playbook at the root of the `rhc-ose-ansible` folder to test with the following content

```
- hosts: disconnected-git
  roles:
    - disconnected-git
```
- Run the playbook

```
ansible-playbook -i inventory/disconnected-git disconnected-git.yml
```
- Once the ansible run completed successfully, clone one of the OpenShift examples

```
git clone http://<server_ip>/git/openshift/openshift-quickstarts.git
```
#### Is there a relevant Issue open for this?

N/A
#### Who would you like to review this?

/cc @etsauer @oybed @JayKayy 
