### PR TITLE
Add sudo to docker role

### DIFF
--- a/rhc-ose-ansible/ose-provision.yml
+++ b/rhc-ose-ansible/ose-provision.yml
@@ -37,5 +37,5 @@
     - openshift_nodes
   roles:
     - { role: subscription-manager, when: hostvars.localhost.rhsm_register, tags: 'subscription-manager', ansible_sudo: true }
-    - { role: docker, tags: 'docker' }
+    - { role: docker, tags: 'docker', ansible_sudo: true }
     - { role: openshift-provision, tags: 'openshift-provision', ansible_sudo: true }


### PR DESCRIPTION
#### What does this PR do?

Adds **ansible_sudo: true** to docker role. Without this, docker will fail to install using a non-root user in an image such as the _rhel-guest-image_.
#### How should this be manually tested?

Run **ose-provision.yml** using an image that does not use the user _root_ such as the _rhel-guest-image_
#### Is there a relevant Issue open for this?

None.
#### Who would you like to review this?

/cc @oybed @sabre1041 @etsauer 
