### PR TITLE
DNS fix to support OSEv3.2

### DIFF
--- a/rhc-ose-ansible/inventory/ose-provision
+++ b/rhc-ose-ansible/inventory/ose-provision
@@ -33,8 +33,9 @@ rhsm_pool=''
 # A better place for this is the group_vars/ to use proper yaml lists, but can be specified as such in inventory:
 rhsm_repos='["rhel-7-server-rpms", "rhel-7-server-ose-3.1-rpms", "rhel-7-server-extras-rpms"]'
 
-#DNS Settings
+# DNS Settings
 dns_domain="example.com"
+public_dns_forwarder="8.8.8.8"
 
 # OpenShift Ansible Path - required when running openshift-ansible from cloned git repo rather than atomic-openshift-utils
 # openshift_ansible_path='/root/repository/openshift-ansible/'

--- a/rhc-ose-ansible/ose-provision.yml
+++ b/rhc-ose-ansible/ose-provision.yml
@@ -84,12 +84,12 @@
       regexp: "nameserver {%for host in groups['dns']%} {{ hostvars[host].dns_private_ip }} {% endfor %}"
       line: "nameserver {%for host in groups['dns']%} {{ hostvars[host].dns_private_ip }} {% endfor %}"
       insertafter: search*
-  - name: "Include DHCP workaround for OSE 3.2"
+  - name: "Include DHCP/DNS workaround for OSE 3.2"
     lineinfile:
       state: present
       dest: /etc/sysconfig/network
-      regexp: "DHCP4_DOMAIN_NAME_SERVERS={%for host in groups['dns']%}{{ hostvars[host].dns_private_ip }}{% endfor %}"
-      line: "DHCP4_DOMAIN_NAME_SERVERS={%for host in groups['dns']%}{{ hostvars[host].dns_private_ip }}{% endfor %}"
+      regexp: "IP4_NAMESERVERS={%for host in groups['dns']%}{{ hostvars[host].dns_private_ip }}{% endfor %}"
+      line: "IP4_NAMESERVERS={%for host in groups['dns']%}{{ hostvars[host].dns_private_ip }}{% endfor %}"
   roles:
     - { role: docker, tags: 'docker' }
     - { role: openshift-provision, tags: 'openshift-provision', ansible_sudo: true }

--- a/rhc-ose-ansible/playbooks/templates/named_views.template
+++ b/rhc-ose-ansible/playbooks/templates/named_views.template
@@ -16,3 +16,5 @@ named_config_views:
   - name: "public"
     zone:
     - "dns_domain": "{{ dns_domain }}"
+    forwarder:
+    - "{{ public_dns_forwarder }}"

--- a/rhc-ose-ansible/roles/dns-server/templates/named.conf.options.j2
+++ b/rhc-ose-ansible/roles/dns-server/templates/named.conf.options.j2
@@ -37,7 +37,7 @@ options {
 	   attacks. Implementing BCP38 within your network would greatly
 	   reduce such attack surface
 	*/
-	recursion no;
+	recursion yes;
 
 	dnssec-enable yes;
 	dnssec-validation yes;


### PR DESCRIPTION
#### What does this PR do?

This PR fixes the installation of OSE v3.2, using Ansible, and the new DNS feature. Lately, the variable used to control this was changed to use "IP4_NAMESERVERS", so the tools now honors this variable. Also, the DNS server configuration was missing a valid forwarder, so that can now be configured through the inventory file with the `public_dns_forwarder` variable. Lastly, to make DNS resolution work properly for our use cases, recursion should also be enabled on the DNS server - this PR takes care of that.
#### How should this be manually tested?

run the "provision" command with the proper inventory file and OSE installer, e.g.:

```
./provision.sh -i=<path_to_inventory> -p=<path_to_OSE_installer>
```

**Note:** that the inventory file now has a new variable, `public_dns_forwarder`, which should be set to a valid DNS server within the environment that the local DNS server can forward requests to.
#### Is there a relevant Issue open for this?

N/A
#### Who would you like to review this?

/cc @etsauer @sabre1041 
