### PR TITLE
Bugfix: Image name for DNS server becomes configurable.

### DIFF
--- a/rhc-ose-ansible/playbooks/dns-provision.yaml
+++ b/rhc-ose-ansible/playbooks/dns-provision.yaml
@@ -7,7 +7,7 @@
     - role: openstack-create
       type: "dns"
       key_name: "{{ openstack_key_name }}"
-      image_name: "_OS1_rhel-guest-image-7.2-20151102.0.x86_64.qcow2"
+      image_name: "{{ openshift_openstack_image_name }}"
       flavor_name: "m1.small"
       security_groups: "dns,default"
       register_host_group: "dns"


### PR DESCRIPTION
#### What does this PR do?

Makes the image for the dns server configurable.
#### How should this be manually tested?

Set `openshift_openstack_image_name` to a value other than '_OS1_rhel_guest_image_blah' and see that a DNS server is created when running:

`./provision.sh -i=./inventory/ose-provision -p=/root/repository/openshift-ansible`
#### Is there a relevant Issue open for this?

n/a
#### Who would you like to review this?

@oybed @vvaldez @sabre1041 
