### PR TITLE
Re-implements original subscription-manager role invokation that was removed in PR# 168.

### DIFF
--- a/rhc-ose-ansible/ose-provision.yml
+++ b/rhc-ose-ansible/ose-provision.yml
@@ -49,7 +49,7 @@
 
 - hosts: all:!localhost
   roles:
-    - role: subscription-manager
+    - { role: subscription-manager, when: hostvars.localhost.rhsm_register, tags: 'subscription-manager', ansible_sudo: true }
 
 - hosts: dns
   pre_tasks:


### PR DESCRIPTION
#### What does this PR do?

Re-adds the following when the subscription-manager role is called:
- conditional check to make sure pre_tasks verification of variables was processed properly to call the role
- tags the role
- enables ansible_sudo
#### How should this be manually tested?

Provision an environment using subscription-manager variables
#### Is there a relevant Issue open for this?

None though I recall seeing the use of **become** instead of **ansible_sudo** at one point but not in the current code.
#### Who would you like to review this?

/cc @oybed @etsauer @sabre1041 
