### PR TITLE
Adds UDP port 53 security group rule on type=DNS

### DIFF
--- a/rhc-ose-ansible/roles/openstack-create/tasks/main.yml
+++ b/rhc-ose-ansible/roles/openstack-create/tasks/main.yml
@@ -33,6 +33,20 @@
   shell: nova secgroup-add-rule {{ security_groups.split(',').0 }} tcp 22 22 0.0.0.0/0
   when: not ssh_rule_found
 
+- name: "Check for DNS rule in Security Groups"
+  set_fact:
+    dns_rule_found: true
+  when:
+    - item.stdout | search('udp.*53.*53')
+    - type == "dns"
+  with_items: secgroup_rule_list.results
+
+- name: "Create DNS Rule in first Security Group if required"
+  shell: nova secgroup-add-rule {{ security_groups.split(',').0 }} udp 53 53 0.0.0.0/0
+  when:
+    - dns_rule_found is not defined
+    - type == "dns"
+
 - name: "Search for valid OpenStack Flavor"
   shell: "nova flavor-list | awk \"/{{flavor_name }}/\"'{print $2}'"
   register: flavor_query


### PR DESCRIPTION
#### What does this PR do?

Adds UDP oprt 53 security group rule if it does not exist on type=DNS during openstack-create role
#### How should this be manually tested?

Remove any UDP port 53 security group rules then provision an environment.
#### Is there a relevant Issue open for this?

None.
#### Who would you like to review this?

/cc @oybed @etsauer @sabre1041 
