### PR TITLE
Enable execution from non-root user to edit resolv.conf

### DIFF
--- a/rhc-ose-ansible/ose-provision.yml
+++ b/rhc-ose-ansible/ose-provision.yml
@@ -71,6 +71,7 @@
 
 # Use newly configured DNS server for this container ...
 - hosts: localhost
+  become: yes
   tasks:
   - name: "Edit /etc/resolv.conf in container"
     shell: "sed '0,/.*nameserver.*/s/.*nameserver.*/nameserver {%for host in groups['dns']%}{{ hostvars[host].dns_public_ip }}{% endfor %}\\n&/' /etc/resolv.conf > /tmp/resolv.conf && /bin/cp -f /tmp/resolv.conf /etc/resolv.conf"


### PR DESCRIPTION
#### What does this PR do?

This adds **become: yes** to the play run on localhost to edit resolv.conf as a non-root user. Enabling sudo should not have a negative affect even if this playbook is run as root. This can also be accomplished by setting the variable **ansible_sudo: true** but that is a per-role or per-task setting, where become is per-play.

Addresses Issue #198
#### How should this be manually tested?

Run **ose-provision.yml** from a VM as a with sudo access.
#### Is there a relevant Issue open for this?

We can/should discuss in more detail. If a hard requirement is for users/customers to execute this as the root user this PR can be closed. However, I think there is value in enabling sudo in this manner. It also explicitly requests privilege escalation rather than implicitly expecting it. We should also discuss replacing any other references of **ansible_sudo: true** in other plays/roles/tasks to **become: yes** instead.
#### Who would you like to review this?

/cc @oybed @etsauer @sabre1041 
