### PR TITLE
updated rdo relase for RPM install

### DIFF
--- a/docker/openshift-host-builder/Dockerfile
+++ b/docker/openshift-host-builder/Dockerfile
@@ -9,7 +9,7 @@ RUN yum update -y; \
     yum install -y \
 	python-devel \
 	https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-	https://repos.fedorapeople.org/repos/openstack/openstack-liberty/rdo-release-liberty-3.noarch.rpm && \
+	https://repos.fedorapeople.org/repos/openstack/openstack-liberty/rdo-release-liberty-5.noarch.rpm && \
     sed -i -e "s/^enabled=1/enabled=0/" /etc/yum.repos.d/epel.repo && \
     yum install -y \
 	git \


### PR DESCRIPTION
#### What does this PR do?

Updated rdo-release-liberty RPM version as previous one is no longer available
#### How should this be manually tested?

Create the openshift-hostbuilder image/container and verify that it can be used for installs of the OSEv3 environments.
#### Is there a relevant Issue open for this?

N/A
#### Who would you like to review this?

/cc @sabre1041 
