### PR TITLE
Adds pre_task to checks to address Issue #178

### DIFF
--- a/rhc-ose-ansible/ose-provision.yml
+++ b/rhc-ose-ansible/ose-provision.yml
@@ -5,6 +5,7 @@
   - include: roles/openstack-create/pre_tasks/pre_tasks.yml
   - include: roles/common/pre_tasks/pre_tasks.yml
   - include: roles/subscription-manager/pre_tasks/pre_tasks.yml
+  - include: roles/openshift-install/pre_tasks/pre_tasks.yml
   roles:
     - role: common
     - role: openshift-common

--- a/rhc-ose-ansible/provision.sh
+++ b/rhc-ose-ansible/provision.sh
@@ -7,8 +7,21 @@ provision() {
   # Grab newly create inventory file
   openshift_inventory=$(ls -Art inventory_* | tail -n 1)
 
+  # Obtain installer path from inventory file
+  if [[ -z "${INSTALLER_PATH}" ]]
+  then
+    INSTALLER_PATH=$(awk -F= "/^openshift_ansible_path=/"'{print $2}' ${openshift_inventory})
+  fi
+
+  # Obtain installer playbook from inventory file
+  if [[ -z "${INSTALLER_PLAYBOOK}" ]]
+  then
+    INSTALLER_PLAYBOOK=$(awk -F= "/^openshift_ansible_playbook=/"'{print $2}' ${openshift_inventory})
+  fi
+
   # Run the OpenShift Installer
-  ansible-playbook -i ${openshift_inventory} ${INSTALLER_PATH}/playbooks/byo/config.yml
+  echo "Executing: ansible-playbook -i ${openshift_inventory} ${INSTALLER_PATH}/${INSTALLER_PLAYBOOK}"
+  ansible-playbook -i ${openshift_inventory} ${INSTALLER_PATH}/${INSTALLER_PLAYBOOK}
 }
 
 # Process input
@@ -20,6 +33,9 @@ do
       shift;;
     --installer-path=*|-p=*)
       INSTALLER_PATH="${i#*=}"
+      shift;;
+    --installer-playbook=*|-b=*)
+      INSTALLER_PLAYBOOK="${i#*=}"
       shift;;
     --help|-h)
       usage

--- a/rhc-ose-ansible/roles/openshift-install/defaults/main.yml
+++ b/rhc-ose-ansible/roles/openshift-install/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+default_openshift_ansible_path: "/usr/share/ansible/openshift-ansible"
+default_openshift_ansible_playbook: "playbooks/byo/config.yml"

--- a/rhc-ose-ansible/roles/openshift-install/pre_tasks/pre_tasks.yml
+++ b/rhc-ose-ansible/roles/openshift-install/pre_tasks/pre_tasks.yml
@@ -1,0 +1,35 @@
+---
+- name: "Load openshift-provision default variables"
+  include_vars: ../defaults/main.yml
+
+- name: "Check for OpenShift Ansible path"
+  stat:
+    path: "{{ openshift_ansible_path | default(default_openshift_ansible_path) }}"
+  register: openshift_ansible_path_check
+  ignore_errors: yes
+
+- name: "Verify OpenShift Ansible path is accessible"
+  fail:
+    msg: "Unable to access{{':'}}{{ openshift_ansible_path | default(default_openshift_ansible_path) }}"
+  when: openshift_ansible_path_check.stat.isdir is undefined
+
+- name: "Verify OpenShift Ansible path is a directory"
+  fail:
+    msg: "Specified path is not a directory{{':'}}{{ openshift_ansible_path | default(default_openshift_ansible_path) }}"
+  when: not openshift_ansible_path_check.stat.isdir
+
+- name: "Check for OpenShift Ansible playbook"
+  stat:
+    path: "{{ openshift_ansible_path | default(default_openshift_ansible_path) }}/{{openshift_ansible_playbook | default(default_openshift_ansible_playbook) }}"
+  register: openshift_ansible_playbook_check
+  ignore_errors: yes
+
+- name: "Verify OpenShift Ansible playbook is accessible"
+  fail:
+    msg: "Unable to access{{':'}}{{ openshift_ansible_path | default(default_openshift_ansible_path) }}/{{ openshift_ansible_playbook | default(default_openshift_ansible_playbook) }}"
+  when: openshift_ansible_playbook_check.stat.isreg is undefined
+
+- name: "Verify OpenShift Ansible playbook is a file"
+  fail:
+    msg: "Specified playbook is not a directory{{':'}}{{ openshift_ansible_path | default(default_openshift_ansible_path) }}/{{ openshift_ansible_playbook | default(default_openshift_ansible_playbook) }}"
+  when: not openshift_ansible_playbook_check.stat.isreg

--- a/rhc-ose-ansible/roles/openshift-install/tasks/main.yaml
+++ b/rhc-ose-ansible/roles/openshift-install/tasks/main.yaml
@@ -1,9 +1,13 @@
 ---
+- name: "Setting OpenShift Install Facts"
+  set_fact:
+    openshift_ansible_path: "{{ openshift_ansible_path | default( default_openshift_ansible_path) }}"
+    openshift_ansible_playbook: "{{ openshift_ansible_playbook | default( default_openshift_ansible_playbook) }}"
 
-  - name: "Creating Inventory"
-    template:
-      dest: "{{rhc_ose_inv_dest | default('/tmp') }}/inventory_{{ hostvars['localhost'].env_id}}"
-      src: "{{ role_path }}/templates/inventory_template.j2"
-      force: yes
+- name: "Creating Inventory"
+  template:
+    dest: "{{rhc_ose_inv_dest | default('/tmp') }}/inventory_{{ hostvars['localhost'].env_id}}"
+    src: "{{ role_path }}/templates/inventory_template.j2"
+    force: yes
 #    - include: /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
 #     when: ose_install | default(true) | bool

--- a/rhc-ose-ansible/roles/openshift-install/templates/inventory_template.j2
+++ b/rhc-ose-ansible/roles/openshift-install/templates/inventory_template.j2
@@ -13,6 +13,8 @@ lb
 
 # Set variables common for all OSEv3 hosts
 [OSEv3:vars]
+openshift_ansible_path={{ openshift_ansible_path }}
+openshift_ansible_playbook={{ openshift_ansible_playbook }}
 {% if ansible_ssh_user is defined %}
 ansible_ssh_user={{ ansible_ssh_user }}
 {% elif ansible_user is defined %}


### PR DESCRIPTION
#### What does this PR do?

Addresses Issue #178 by adding a pre_task check for openshift_ansible_path directory and openshift_ansible_playbook file and will halt the playbook if not found or accessible before any provisioning. Also adds the following to support this feature:
- Adds default variables for openshift_ansible_path and openshift_ansible_playbook
- Checks for accessible path and playbook in pre_task before any provisioning
- Adds these variables to inventory file
- Modifies provision.sh to read these variables from inventory file
- Adds parameter to override these varibles in provision.sh
#### How should this be manually tested?

Run **ose-provision.yml** on a system without the default path of /usr/share/ansible/openshift-ansible or the playbooks/byo/config.yml to ensure the playbook fails. Also attempt specifying a custom path and/or playbook in an inventory or variables file.
#### Is there a relevant Issue open for this?

None.
#### Who would you like to review this?

/cc @oybed @etsauer @sabre1041 
