### PR TITLE
Updated CICD implementation to support ETL OSP env

### DIFF
--- a/rhc-ose-ansible/cicd-provision.yml
+++ b/rhc-ose-ansible/cicd-provision.yml
@@ -18,6 +18,18 @@
       volume_size: "{{ cicd_openstack_storage_size }}"
 
 - hosts: cicd
+  remote_user: "cloud-user"
+  vars:
+    ansible_ssh_user: cloud-user
+  tasks:
+  - name: "Enable direct root access"
+    shell: "cat ~/.ssh/authorized_keys | sudo tee /root/.ssh/authorized_keys >/dev/null"
+
+- hosts: cicd
+  roles:
+    - role: subscription-manager
+
+- hosts: cicd
   roles:
   - cicd-common
   - cicd

--- a/rhc-ose-ansible/inventory/cicd-provision
+++ b/rhc-ose-ansible/inventory/cicd-provision
@@ -3,10 +3,35 @@
 # Enter the security key to provision new OpenStack instances
 openstack_key_name=""
 
+# Update the 'env_id' with a desirable name (optional)
+#env_id=""
+
 # The following variables can be used to override the defaults
 #cicd_storage_disk_volume=/dev/vdb
 #cicd_openstack_flavor_name="m1.medium"
 #cicd_openstack_security_groups="CI-CD"
-#cicd_openstack_image_name="ose3_1-base"
-#cicd_openstack_storage_size: 10
-#cicd_instance_count: 1
+#cicd_openstack_image_name="rhel-guest-image-7.2"
+#cicd_openstack_storage_size=10
+#cicd_instance_count=1
+
+
+# Subscription Manager Satellite hostname. If using a Satellite server, set the FQDN here. For RHSM Hosted this value must be blank, none or false.
+rhsm_satellite=''
+
+# Subscription Manager username and password. Required for RHSM Hosted. Can be optionally used for Satellite, but it may be better to use 'rhsm_activationkey' for this
+rhsm_username=''
+rhsm_password=''
+
+# Optional Subscription Manager Satellite Organization - required for Satellite, ignored if using RHSM Hosted
+rhsm_org=''
+
+# Optional Subscription Manager Satellite Activation Key, use this instead of 'rhsm_username' and 'rhsm_password' if using Satellite to provide repositories and authentication in one key
+rhsm_activationkey=''
+
+# Optional Subscription Manager pool, determine this by running 'subscription-manager list --available' on a registered system. Valid for RHSM Hosted or Satellite
+rhsm_pool=''
+
+# Optional Repositories to enable. If left blank it is expected that the 'rhsm_activationkey' will specify repos instead.  If populated, a 'subscription-manager repos --disable=*' will be run and each of the specified repos explicitly enabled. Valid for RHSM Hosted or Satellite
+# A better place for this is the group_vars/ to use proper yaml lists, but can be specified as such in inventory:
+rhsm_repos='["rhel-7-server-rpms", "rhel-7-server-ose-3.1-rpms", "rhel-7-server-extras-rpms"]'
+

--- a/rhc-ose-ansible/roles/cicd/tasks/prerequisites.yml
+++ b/rhc-ose-ansible/roles/cicd/tasks/prerequisites.yml
@@ -3,7 +3,7 @@
 - name: Installing Prerequisite Software
   yum: state=present name={{item}}
   with_items:
-  - http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+  - http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   - wget
   - firewalld
   - unzip


### PR DESCRIPTION
#### What does this PR do?

Updated CI/CD ansible implementation to support a more generic OSP environment, including ETL.
#### How should this be manually tested?

Use the CI/CD Ansible playbook to deploy a Jenkins/Nexus combination
#### Is there a relevant Issue open for this?

N/A
#### Who would you like to review this?

/cc @sabre1041 @etsauer 
