### PR TITLE
Corrected release url for rdo release rpm

### DIFF
--- a/docker/openstack-docker-client/Dockerfile
+++ b/docker/openstack-docker-client/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Andrew Block “andrew.block@redhat.com”
 ADD bin/start.sh /root/
 
 # Update System and install clients
-RUN yum install -y https://repos.fedorapeople.org/repos/openstack/openstack-liberty/rdo-release-liberty-3.noarch.rpm; \
+RUN yum install -y https://repos.fedorapeople.org/repos/openstack/openstack-liberty/rdo-release-liberty-5.noarch.rpm; \
   yum update -y; \
   yum install -y python-devel epel-release; \
 	yum install -y git tar bind-utils ansible1.9 python-pip python-ceilometerclient python-cinderclient python-glanceclient python-heatclient python-neutronclient python-novaclient python-saharaclient python-swiftclient python-troveclient python-openstackclient python-passlib; \


### PR DESCRIPTION
#### What does this PR do?

This PR fixes the url to the rdo rpm.
#### How should this be manually tested?

Execute run.sh and ensure that the openstack tools are installed.
#### Is there a relevant Issue open for this?

Not at the moment.
#### Who would you like to review this?

/cc @oybed @etsauer @sabre1041 
