### PR TITLE
Adding NFS support and fixing template labels so we get a router and …

### DIFF
--- a/rhc-ose-ansible/ose-provision.yml
+++ b/rhc-ose-ansible/ose-provision.yml
@@ -6,36 +6,46 @@
   - include: roles/common/pre_tasks/pre_tasks.yml
   - include: roles/subscription-manager/pre_tasks/pre_tasks.yml
   roles:
-    - role: common
-    - role: openshift-common
-    # Provision Master
-    - role: openstack-create
-      type: "master"
-      image_name: "{{ openshift_openstack_image_name }}"
-      security_groups: "{{ openshift_openstack_master_security_groups }}"
-      key_name: "{{ openstack_key_name }}"
-      flavor_name: "{{ openshift_openstack_flavor_name }}"
-      register_host_group: "masters"
-      node_count: "{{ openshift_master_count }}"
-      disk_volume: "{{ openshift_storage_disk_volume }}"
-      volume_size: "{{ openshift_openstack_master_storage_size }}"
-    # Provision Nodes
-    - role: openstack-create
-      type: "node"
-      image_name: "{{ openshift_openstack_image_name }}"
-      security_groups: "{{ openshift_openstack_node_security_groups }}"
-      key_name: "{{ openstack_key_name }}"
-      flavor_name: "{{ openshift_openstack_flavor_name }}"
-      register_host_group: "nodes"
-      node_count: "{{ openshift_node_count }}"
-      disk_volume: "{{ openshift_storage_disk_volume }}"
-      volume_size: "{{ openshift_openstack_master_storage_size }}"
-
+  - role: common
+  - role: openshift-common
+  # Provision Master
+  - role: openstack-create
+    type: "master"
+    image_name: "{{ openshift_openstack_image_name }}"
+    security_groups: "{{ openshift_openstack_master_security_groups }}"
+    key_name: "{{ openstack_key_name }}"
+    flavor_name: "{{ openshift_openstack_flavor_name }}"
+    register_host_group: "masters,openshift"
+    node_count: "{{ openshift_master_count }}"
+    disk_volume: "{{ openshift_storage_disk_volume }}"
+    volume_size: "{{ openshift_openstack_master_storage_size }}"
+  # Provision Nodes
+  - role: openstack-create
+    type: "node"
+    image_name: "{{ openshift_openstack_image_name }}"
+    security_groups: "{{ openshift_openstack_node_security_groups }}"
+    key_name: "{{ openstack_key_name }}"
+    flavor_name: "{{ openshift_openstack_flavor_name }}"
+    register_host_group: "nodes,openshift"
+    node_count: "{{ openshift_node_count }}"
+    disk_volume: "{{ openshift_storage_disk_volume }}"
+    volume_size: "{{ openshift_openstack_master_storage_size }}"
+  # Provision NFS
+  - role: openstack-create
+    type: "nfs"
+    image_name: "{{ openshift_openstack_image_name }}"
+    security_groups: "default"
+    key_name: "{{ openstack_key_name }}"
+    flavor_name: "{{ openshift_openstack_flavor_name }}"
+    register_host_group: "nfs,openshift"
+    node_count: "1"
+    disk_volume: "{{ openshift_storage_disk_volume }}"
+    volume_size: "{{ openshift_openstack_master_storage_size }}"
     # Provision DNS
 
 - include: playbooks/dns-provision.yaml
 
-- hosts: dns:masters:nodes
+- hosts: openshift
   remote_user: "cloud-user"
   vars:
     ansible_ssh_user: cloud-user
@@ -78,7 +88,7 @@
 
 # Install and configure OpenShift
 
-- hosts: masters:nodes
+- hosts: openshift:!dns
   tasks:
   - name: "Edit /etc/resolv.conf on masters/nodes"
     lineinfile:
@@ -100,4 +110,3 @@
 - hosts: localhost
   roles:
     - openshift-install
-

--- a/rhc-ose-ansible/playbooks/dns-provision.yaml
+++ b/rhc-ose-ansible/playbooks/dns-provision.yaml
@@ -10,5 +10,5 @@
       image_name: "{{ openshift_openstack_image_name }}"
       flavor_name: "m1.small"
       security_groups: "dns,default"
-      register_host_group: "dns"
+      register_host_group: "dns,openshift"
       node_count: "1"

--- a/rhc-ose-ansible/playbooks/templates/named_views.template
+++ b/rhc-ose-ansible/playbooks/templates/named_views.template
@@ -2,13 +2,7 @@
 named_config_views:
   - name: "private"
     acl_entry:
-{% for host in groups['nodes']%}
-    - "{{ hostvars[host]["dns_private_ip"] }}/32"
-{% endfor %}
-{% for host in groups['masters']%}
-    - "{{ hostvars[host]["dns_private_ip"] }}/32"
-{% endfor %}
-{% for host in groups['dns']%}
+{% for host in groups['openshift']%}
     - "{{ hostvars[host]["dns_private_ip"] }}/32"
 {% endfor %}
     zone:

--- a/rhc-ose-ansible/playbooks/templates/records.template.yaml
+++ b/rhc-ose-ansible/playbooks/templates/records.template.yaml
@@ -3,26 +3,16 @@ dns_records_add:
   - view: private
     zone: {{ dns_domain }}
     entries:
-{% for mst in groups['masters'] %}
+{% for host in groups['openshift'] %}
     - type: A
-      hostname: {{ hostvars[mst]['ansible_hostname'] }}
-      ip: {{ hostvars[mst]['dns_private_ip'] }}
-{% endfor %}
-{% for node in groups['nodes'] %}
-    - type: A
-      hostname: {{ hostvars[node]['ansible_hostname'] }}
-      ip: {{ hostvars[node]['dns_private_ip'] }}
+      hostname: {{ hostvars[host]['ansible_hostname'] }}
+      ip: {{ hostvars[host]['dns_private_ip'] }}
 {% endfor %}
   - view: public
     zone: {{ dns_domain}}
     entries:
-{% for mst in groups['masters']%}
+{% for host in groups['openshift']%}
     - type: A
-      hostname: {{ hostvars[mst]['ansible_hostname'] }}
-      ip: {{ hostvars[mst]['dns_public_ip'] }}
-{% endfor %}
-{% for node in groups['nodes'] %}
-    - type: A
-      hostname: {{ hostvars[node]['ansible_hostname'] }}
-      ip: {{ hostvars[node]['dns_public_ip'] }}
+      hostname: {{ hostvars[host]['ansible_hostname'] }}
+      ip: {{ hostvars[host]['dns_public_ip'] }}
 {% endfor %}

--- a/rhc-ose-ansible/roles/openshift-install/templates/inventory_template.j2
+++ b/rhc-ose-ansible/roles/openshift-install/templates/inventory_template.j2
@@ -10,6 +10,9 @@ etcd
 {% if groups['lb'] is defined %}
 lb
 {% endif %}
+{% if groups['nfs'] is defined %}
+nfs
+{% endif %}
 
 # Set variables common for all OSEv3 hosts
 [OSEv3:vars]
@@ -71,17 +74,25 @@ openshift_master_cluster_public_hostname={{ rhc_ose_cluster_public_hostname }}
 {% endfor %}
 {% endif %}
 
+{% if groups['nfs'] is defined %}
+# Specify load balancer host
+[nfs]
+{% for inv_nfs in groups['nfs'] %}
+{{ hostvars[inv_nfs]['ansible_hostname'] }}.{{dns_domain}} openshift_hostname={{ hostvars[inv_nfs]['ansible_hostname'] }}.{{dns_domain}} openshift_public_hostname={{ hostvars[inv_nfs]['ansible_hostname'] }}.{{dns_domain}}
+{% endfor %}
+{% endif %}
+
 # host group for nodes, includes region info
 [nodes]
 {% for inv_master in groups['masters'] %}
-{{ hostvars[inv_master]['ansible_hostname'] }}.{{dns_domain}} openshift_hostname={{ hostvars[inv_master]['ansible_hostname'] }}.{{dns_domain}} openshift_public_hostname={{ hostvars[inv_master]['ansible_hostname'] }}.{{dns_domain}} openshift_node_labels="{'type': 'master'}"
+{{ hostvars[inv_master]['ansible_hostname'] }}.{{dns_domain}} openshift_hostname={{ hostvars[inv_master]['ansible_hostname'] }}.{{dns_domain}} openshift_public_hostname={{ hostvars[inv_master]['ansible_hostname'] }}.{{dns_domain}} openshift_node_labels="{'region': 'master'}"
 {% endfor %}
 {% set counter = 0 %}
 {% for inv_node in groups['nodes'] %}
 {% if counter == 0%}
-{{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_public_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_node_labels="{'type': 'infra'}"
+{{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_public_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_node_labels="{'region': 'infra'}"
 {% else %}
-{{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_public_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_node_labels="{'type': 'app'}"
+{{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_public_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_node_labels="{'region': 'app'}"
 {% endif %}
 {% set counter = counter + 1%}
 {% endfor -%}


### PR DESCRIPTION
…registry out of the box.
#### What does this PR do?

Adds an NFS server to the ose-provision process for supporting creation of a registry out of the box. The NFS server is passed to the openshift-ansible installer in the inventory file. This PR also changes the label name from 'type' to 'region' for the openshift nodes, in order to allow the installer to create the router and registry as expected.
#### How should this be manually tested?

Run `provision.sh -i=./inventory_file -p=./openshift-ansible/`.
#### Is there a relevant Issue open for this?

n/a
#### Who would you like to review this?

/cc @oybed @sabre1041 @vvaldez 
