### PR TITLE
Fixes Issue #163 if rhsm_password is not defined

### DIFF
--- a/rhc-ose-ansible/roles/subscription-manager/pre_tasks/pre_tasks.yml
+++ b/rhc-ose-ansible/roles/subscription-manager/pre_tasks/pre_tasks.yml
@@ -1,12 +1,8 @@
 ---
 - name: "Set password fact"
   set_fact:
-    rhsm_password: "{{ rhsm_password }}"
+    rhsm_password: "{{ rhsm_password | default(None) }}"
   no_log: true
-  when:
-    - rhsm_password is defined
-    - rhsm_password is not none
-    - rhsm_password|trim != ''
 
 - name: "Initialize Subscription Manager fact"
   set_fact:


### PR DESCRIPTION
#### What does this PR do?

Changes the **set_fact** task in subscription-manager **pre_task** that sets the **rhsm_password**. Previously this task was assuming if the password was not being used it was being set to **rhsm_password=''**. This PR changes the check to default to **None** if no password is set.
#### How should this be manually tested?

Run a provision without **rhsm_password** set
#### Is there a relevant Issue open for this?

Fixes Issue #163.
#### Who would you like to review this?

/cc @etsauer 
