### PR TITLE
Update Instance names to be <instance>.<env_id>.<dns_domain> style

### DIFF
--- a/rhc-ose-ansible/inventory/ose-provision
+++ b/rhc-ose-ansible/inventory/ose-provision
@@ -12,6 +12,11 @@ openstack_key_name=""
 # if env_id is set to a fixed value, it will be used as the id - ex: if set to 'env1', the oucome will be 'master1.env1.example.com'
 #env_id=
 
+# What sub-domain to use for apps url - should match the wild card DNS record
+# For example, if set to "apps", the default subdomain would be: '*.apps.env1.example.com'
+# Default value is 'apps'.
+#openshift_app_domain=apps
+
 # The following variables can be used to override the defaults
 #openshift_master_count=1
 #openshift_node_count=2

--- a/rhc-ose-ansible/inventory/ose-provision
+++ b/rhc-ose-ansible/inventory/ose-provision
@@ -6,6 +6,10 @@
 
 # Enter the security key to provision new OpenStack instances
 openstack_key_name=""
+
+# if env_id is left disabled, the tools will auto-generate a unique id to be used - ex: 'master1.casl-userid-12312334.example.com'
+# if env_id is enabled, but left blank, (e.g.: env_id=), no id will be inserted - ex: 'master1.example.com'
+# if env_id is set to a fixed value, it will be used as the id - ex: if set to 'env1', the oucome will be 'master1.env1.example.com'
 #env_id=
 
 # The following variables can be used to override the defaults

--- a/rhc-ose-ansible/ose-provision.yml
+++ b/rhc-ose-ansible/ose-provision.yml
@@ -54,23 +54,27 @@
     shell: "cat ~/.ssh/authorized_keys | sudo tee /root/.ssh/authorized_keys >/dev/null"
 
 - hosts: all:!dns:!localhost
+  pre_tasks:
+  - include: roles/common/pre_tasks/pre_tasks.yml
   roles:
-    - role: hostnames
+  - role: hostnames
 
 - hosts: all:!localhost
   roles:
     - { role: subscription-manager, when: hostvars.localhost.rhsm_register, tags: 'subscription-manager', ansible_sudo: true }
 
-- hosts: dns
+- hosts: localhost
   pre_tasks:
+  - include: roles/common/pre_tasks/pre_tasks.yml
   - name: "Generate dns-server views"
     include: playbooks/dns_dual_view.yaml
-    delegate_to: localhost
-  - name: "Include the generated views"
-    include_vars: /tmp/named_views.yaml
-    delegate_to: localhost
   - name: "Generate dns records"
     include: playbooks/dns_records.yaml
+
+- hosts: dns
+  pre_tasks:
+  - name: "Include the generated views"
+    include_vars: /tmp/named_views.yaml
     delegate_to: localhost
   - name: "Include generated dns records"
     include_vars: /tmp/records.yaml

--- a/rhc-ose-ansible/playbooks/templates/named_views.template
+++ b/rhc-ose-ansible/playbooks/templates/named_views.template
@@ -6,9 +6,9 @@ named_config_views:
     - "{{ hostvars[host]["dns_private_ip"] }}/32"
 {% endfor %}
     zone:
-    - "dns_domain": "{{ dns_domain }}"
+    - "dns_domain": "{{ full_dns_domain }}"
   - name: "public"
     zone:
-    - "dns_domain": "{{ dns_domain }}"
+    - "dns_domain": "{{ full_dns_domain }}"
     forwarder:
     - "{{ public_dns_forwarder }}"

--- a/rhc-ose-ansible/playbooks/templates/records.template.yaml
+++ b/rhc-ose-ansible/playbooks/templates/records.template.yaml
@@ -1,7 +1,7 @@
 ---
 dns_records_add:
   - view: private
-    zone: {{ dns_domain }}
+    zone: {{ full_dns_domain }}
     entries:
 {% for host in groups['openshift'] %}
     - type: A
@@ -9,7 +9,7 @@ dns_records_add:
       ip: {{ hostvars[host]['dns_private_ip'] }}
 {% endfor %}
   - view: public
-    zone: {{ dns_domain}}
+    zone: {{ full_dns_domain}}
     entries:
 {% for host in groups['openshift']%}
     - type: A

--- a/rhc-ose-ansible/roles/common/defaults/main.yml
+++ b/rhc-ose-ansible/roles/common/defaults/main.yml
@@ -1,2 +1,1 @@
 ---
-default_env_id: "casl-{{ lookup('env','OS_USERNAME') }}"

--- a/rhc-ose-ansible/roles/common/pre_tasks/pre_tasks.yml
+++ b/rhc-ose-ansible/roles/common/pre_tasks/pre_tasks.yml
@@ -1,4 +1,21 @@
 ---
 - name: Generate Environment ID
-  shell: echo "$(date +%s)"
-  register: env_random_id
+  set_fact:
+    env_random_id: "{{ ansible_date_time.epoch }}"
+  run_once: true
+  delegate_to: localhost
+
+- name: Set default Environment ID
+  set_fact:
+    default_env_id: "casl-{{ lookup('env','OS_USERNAME') }}-{{ env_random_id }}"
+  delegate_to: localhost
+
+- name: Setting Common Facts
+  set_fact:
+    env_id: "{{ env_id | default(default_env_id) }}"
+  delegate_to: localhost
+
+- name: Updating DNS domain to include env_id (if not empty)
+  set_fact:
+    full_dns_domain: "{{ (env_id|trim == '') | ternary(dns_domain, env_id + '.' + dns_domain) }}"
+  delegate_to: localhost

--- a/rhc-ose-ansible/roles/common/tasks/main.yml
+++ b/rhc-ose-ansible/roles/common/tasks/main.yml
@@ -1,4 +1,1 @@
 ---
-- name: Setting Common Facts
-  set_fact:
-    env_id: "{{ env_id | default(default_env_id) }}-{{ env_random_id.stdout }}"

--- a/rhc-ose-ansible/roles/hostnames/tasks/main.yaml
+++ b/rhc-ose-ansible/roles/hostnames/tasks/main.yaml
@@ -1,11 +1,11 @@
 ---
 - name: Setting Hostname Fact
   set_fact:
-    new_hostname: "{{ custom_hostname | default(inventory_hostname) }}"
+    new_hostname: "{{ custom_hostname | default(inventory_hostname_short) }}"
 
 - name: Setting FQDN Fact
   set_fact:
-    new_fqdn: "{{ new_hostname }}.{{ dns_domain }}"
+    new_fqdn: "{{ new_hostname }}.{{ full_dns_domain }}"
 
 - name: Setting hostname and DNS domain
   hostname: name="{{ new_fqdn }}"

--- a/rhc-ose-ansible/roles/openshift-common/defaults/main.yml
+++ b/rhc-ose-ansible/roles/openshift-common/defaults/main.yml
@@ -2,6 +2,7 @@
 default_openshift_storage_disk_volume: "/dev/vdb"
 default_openshift_master_count: 1
 default_openshift_node_count: 2
+default_openshift_app_domain: "apps"
 
 default_openshift_openstack_master_security_groups: "ose3-master"
 default_openshift_openstack_node_security_groups: "ose3-node"

--- a/rhc-ose-ansible/roles/openshift-common/tasks/main.yml
+++ b/rhc-ose-ansible/roles/openshift-common/tasks/main.yml
@@ -4,6 +4,7 @@
     openshift_storage_disk_volume: "{{ openshift_storage_disk_volume | default(default_openshift_storage_disk_volume) }}"
     openshift_master_count: "{{ openshift_master_count | default(default_openshift_master_count) }}"
     openshift_node_count: "{{ openshift_node_count | default(default_openshift_node_count) }}"
+    openshift_app_domain: "{{ openshift_app_domain | default(default_openshift_app_domain) }}"
     openshift_openstack_master_security_groups: "{{ openshift_openstack_master_security_groups | default(default_openshift_openstack_master_security_groups) }}"
     openshift_openstack_node_security_groups: "{{ openshift_openstack_node_security_groups | default(default_openshift_openstack_node_security_groups) }}"
     openshift_openstack_flavor_name: "{{ openshift_openstack_flavor_name | default(default_openshift_openstack_flavor_name) }}"

--- a/rhc-ose-ansible/roles/openshift-install/templates/inventory_template.j2
+++ b/rhc-ose-ansible/roles/openshift-install/templates/inventory_template.j2
@@ -29,6 +29,7 @@ ansible_sudo={{ ansible_sudo }}
 ansible_sudo={{ become }}
 {% endif %}
 deployment_type=openshift-enterprise
+# openshift_master_default_subdomain={{ openshift_app_domain }}.{{ full_dns_domain }}
 
 # Uncomment the following to enable htpasswd authentication; defaults to
 # DenyAllPasswordIdentityProvider.
@@ -54,7 +55,7 @@ openshift_master_cluster_public_hostname={{ rhc_ose_cluster_public_hostname }}
 # host group for masters
 [masters]
 {% for inv_master in groups['masters'] %}
-{{ hostvars[inv_master]['ansible_hostname'] }}.{{dns_domain}} openshift_hostname={{ hostvars[inv_master]['ansible_hostname'] }}.{{dns_domain}} openshift_public_hostname={{ hostvars[inv_master]['ansible_hostname'] }}.{{dns_domain}}
+{{ hostvars[inv_master]['ansible_hostname'] }}.{{full_dns_domain}} openshift_hostname={{ hostvars[inv_master]['ansible_hostname'] }}.{{full_dns_domain}} openshift_public_hostname={{ hostvars[inv_master]['ansible_hostname'] }}.{{full_dns_domain}}
 
 {% endfor %}
 {% if groups['etcd'] is defined %}
@@ -62,7 +63,7 @@ openshift_master_cluster_public_hostname={{ rhc_ose_cluster_public_hostname }}
 # host group for etcd
 [etcd]
 {% for inv_etcd in groups['etcd'] %}
-{{ hostvars[inv_etcd]['ansible_hostname'] }}.{{dns_domain}} openshift_hostname={{ hostvars[inv_etcd]['ansible_hostname'] }}.{{dns_domain}} openshift_public_hostname={{ hostvars[inv_etcd]['ansible_hostname'] }}.{{dns_domain}}
+{{ hostvars[inv_etcd]['ansible_hostname'] }}.{{full_dns_domain}} openshift_hostname={{ hostvars[inv_etcd]['ansible_hostname'] }}.{{full_dns_domain}} openshift_public_hostname={{ hostvars[inv_etcd]['ansible_hostname'] }}.{{full_dns_domain}}
 {% endfor %}
 {% endif %}
 {% if groups['lb'] is defined %}
@@ -70,7 +71,7 @@ openshift_master_cluster_public_hostname={{ rhc_ose_cluster_public_hostname }}
 # Specify load balancer host
 [lb]
 {% for inv_lbs in groups['lb'] %}
-{{ hostvars[inv_lbs]['ansible_hostname'] }}.{{dns_domain}} openshift_hostname={{ hostvars[inv_etcd]['ansible_hostname'] }}.{{dns_domain}} openshift_public_hostname={{ hostvars[inv_etcd]['ansible_hostname'] }}.{{dns_domain}}
+{{ hostvars[inv_lbs]['ansible_hostname'] }}.{{full_dns_domain}} openshift_hostname={{ hostvars[inv_etcd]['ansible_hostname'] }}.{{full_dns_domain}} openshift_public_hostname={{ hostvars[inv_etcd]['ansible_hostname'] }}.{{full_dns_domain}}
 {% endfor %}
 {% endif %}
 
@@ -78,21 +79,21 @@ openshift_master_cluster_public_hostname={{ rhc_ose_cluster_public_hostname }}
 # Specify load balancer host
 [nfs]
 {% for inv_nfs in groups['nfs'] %}
-{{ hostvars[inv_nfs]['ansible_hostname'] }}.{{dns_domain}} openshift_hostname={{ hostvars[inv_nfs]['ansible_hostname'] }}.{{dns_domain}} openshift_public_hostname={{ hostvars[inv_nfs]['ansible_hostname'] }}.{{dns_domain}}
+{{ hostvars[inv_nfs]['ansible_hostname'] }}.{{full_dns_domain}} openshift_hostname={{ hostvars[inv_nfs]['ansible_hostname'] }}.{{full_dns_domain}} openshift_public_hostname={{ hostvars[inv_nfs]['ansible_hostname'] }}.{{full_dns_domain}}
 {% endfor %}
 {% endif %}
 
 # host group for nodes, includes region info
 [nodes]
 {% for inv_master in groups['masters'] %}
-{{ hostvars[inv_master]['ansible_hostname'] }}.{{dns_domain}} openshift_hostname={{ hostvars[inv_master]['ansible_hostname'] }}.{{dns_domain}} openshift_public_hostname={{ hostvars[inv_master]['ansible_hostname'] }}.{{dns_domain}} openshift_node_labels="{'region': 'master'}"
+{{ hostvars[inv_master]['ansible_hostname'] }}.{{full_dns_domain}} openshift_hostname={{ hostvars[inv_master]['ansible_hostname'] }}.{{full_dns_domain}} openshift_public_hostname={{ hostvars[inv_master]['ansible_hostname'] }}.{{full_dns_domain}} openshift_node_labels="{'region': 'master'}"
 {% endfor %}
 {% set counter = 0 %}
 {% for inv_node in groups['nodes'] %}
 {% if counter == 0%}
-{{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_public_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_node_labels="{'region': 'infra'}"
+{{ hostvars[inv_node]['ansible_hostname'] }}.{{full_dns_domain}} openshift_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{full_dns_domain}} openshift_public_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{full_dns_domain}} openshift_node_labels="{'region': 'infra'}"
 {% else %}
-{{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_public_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{dns_domain}} openshift_node_labels="{'region': 'app'}"
+{{ hostvars[inv_node]['ansible_hostname'] }}.{{full_dns_domain}} openshift_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{full_dns_domain}} openshift_public_hostname={{ hostvars[inv_node]['ansible_hostname'] }}.{{full_dns_domain}} openshift_node_labels="{'region': 'app'}"
 {% endif %}
 {% set counter = counter + 1%}
 {% endfor -%}

--- a/rhc-ose-ansible/roles/openshift-install/templates/inventory_template.j2
+++ b/rhc-ose-ansible/roles/openshift-install/templates/inventory_template.j2
@@ -29,7 +29,7 @@ ansible_sudo={{ ansible_sudo }}
 ansible_sudo={{ become }}
 {% endif %}
 deployment_type=openshift-enterprise
-# openshift_master_default_subdomain={{ openshift_app_domain }}.{{ full_dns_domain }}
+openshift_master_default_subdomain={{ openshift_app_domain }}.{{ full_dns_domain }}
 
 # Uncomment the following to enable htpasswd authentication; defaults to
 # DenyAllPasswordIdentityProvider.

--- a/rhc-ose-ansible/roles/openstack-create/tasks/create-volume.yml
+++ b/rhc-ose-ansible/roles/openstack-create/tasks/create-volume.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Create {{ instance_type }} Attached Storage"
-  shell: "nova volume-create --display-name {{ item.id }} {{ storage_volume_size }} |  awk '/ id / {print $4}'"
+  shell: "nova volume-create --display-name {{ item.info.name + '-volume' }} {{ storage_volume_size }} |  awk '/ id / {print $4}'"
   register: created_volumes
   failed_when: created_volumes.rc != 0
   with_items: openstack_machines.results

--- a/rhc-ose-ansible/roles/openstack-create/tasks/main.yml
+++ b/rhc-ose-ansible/roles/openstack-create/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Validate OpenStack Variables
   fail: msg="Required OpenStack Variables not defined!"
   when: 
-       - image_name is not defined or security_groups is not defined or key_name is not defined or image_name is not defined or flavor_name is not defined or env_id is not defined
+  - image_name is not defined or security_groups is not defined or key_name is not defined or image_name is not defined or flavor_name is not defined 
 
 - name: "Check for Security Groups"
   shell: "nova secgroup-list"
@@ -61,7 +61,7 @@
 
 - name: "Provision OpenStack {{ type }}"
   nova_compute:
-    name: "{{ env_id }}-{{ type }}{{ item }}"
+    name: "{{ type }}{{ item }}.{{ full_dns_domain }}"
     state: present
     image_name: "{{ image_name }}"
     flavor_id: "{{ flavor_id }}"


### PR DESCRIPTION
#### What does this PR do?

This PR changes how hostnames and domains are assigned based on the `env_id` variable. 
If env_id is left disabled, the tools will auto-generate a unique id to be used - ex: 'master1.casl-userid-12312334.example.com'
If env_id is enabled, but left blank, (e.g.: env_id=), no id will be inserted - ex: 'master1.example.com'
If env_id is set to a fixed value, it will be used as the id - ex: if set to 'env1', the outcome will be 'master1.env1.example.com'

This can of course be used in conjunction with the `dns_domain` variable (and the newly introduced `openshift_app_domain` variable), to generate very custom FQDNs. 

This PR also changes how volume names are assigned - i.e.: it will now be named according to the instance a volume is assigned to + the suffix `_volume`
#### How should this be manually tested?

Set `env_id` in the inventory file to various values, then run the provisioning to see the result, e.g.:

```
./provision.sh -i=inventory/my_inventory -p=<path_to_the_repo>/openshift-ansible
```
#### Is there a relevant Issue open for this?

resolves #208 
resolves #216 
#### Who would you like to review this?

/cc @etsauer @sabre1041 
