### PR TITLE
Updated inventory template file to include 'openshift_deployment_type'

### DIFF
--- a/rhc-ose-ansible/roles/openshift-install/templates/inventory_template.j2
+++ b/rhc-ose-ansible/roles/openshift-install/templates/inventory_template.j2
@@ -28,7 +28,10 @@ ansible_sudo={{ ansible_sudo }}
 {% elif become is defined %}
 ansible_sudo={{ become }}
 {% endif %}
+
 deployment_type=openshift-enterprise
+openshift_deployment_type=openshift-enterprise
+
 openshift_master_default_subdomain={{ openshift_app_domain }}.{{ full_dns_domain }}
 
 # Uncomment the following to enable htpasswd authentication; defaults to


### PR DESCRIPTION
#### What does this PR do?

Includes the `openshift_deployment_type` in the inventory template as that's the inventory file  used with the post-install playbook.
#### How should this be manually tested?

Run the post-install portion of the provision.sh script (or just run the entire provision.sh)
#### Is there a relevant Issue open for this?

N/A
#### Who would you like to review this?

/cc @etsauer 
