### PR TITLE
Updated Dockerfile to include python-shade

### DIFF
--- a/docker/openstack-client-centos/Dockerfile
+++ b/docker/openstack-client-centos/Dockerfile
@@ -8,8 +8,15 @@ ADD bin/start.sh /root/
 RUN yum install -y https://repos.fedorapeople.org/repos/openstack/openstack-liberty/rdo-release-liberty-5.noarch.rpm; \
   yum update -y; \
   yum install -y python-devel epel-release; \
-	yum install -y git tar bind-utils ansible python-pip python-ceilometerclient python-cinderclient python-glanceclient python-heatclient python-neutronclient python-novaclient python-saharaclient python-swiftclient python-troveclient python-openstackclient python-passlib; \
- 	yum clean all
+  yum install -y git tar bind-utils ansible \
+                 python-pip python-ceilometerclient \
+                 python-cinderclient python-glanceclient \
+                 python-heatclient python-neutronclient \
+                 python-novaclient python-saharaclient \
+                 python-swiftclient python-troveclient \
+                 python-openstackclient python-passlib; \
+  yum clean all; \
+  pip install shade
 
 # Set /root as starting directory
 WORKDIR /root


### PR DESCRIPTION
#### What does this PR do?

Introduce `python-shade` to support the latest OpenStack modules in ansible.
#### How should this be manually tested?

Build/Spin up a new image of the `openstack-client-centos` instance. Verify that it is successful. Then just run `help('modules')` in python shell to verify that `shade` is part of the list... or run the CASL provisioning to test that there's no breakage.
#### Is there a relevant Issue open for this?

N/A
#### Who would you like to review this?

/cc @sabre1041 @etsauer
