### PR TITLE
Updating dockerfile to be compatible with OSP 9

### DIFF
--- a/docker/openstack-client-centos/Dockerfile
+++ b/docker/openstack-client-centos/Dockerfile
@@ -5,16 +5,17 @@ MAINTAINER Andrew Block “andrew.block@redhat.com”
 ADD bin/start.sh /root/
 
 # Update System and install clients
-RUN yum install -y https://repos.fedorapeople.org/repos/openstack/openstack-liberty/rdo-release-liberty-5.noarch.rpm; \
+RUN yum install -y https://repos.fedorapeople.org/repos/openstack/openstack-mitaka/rdo-release-mitaka-6.noarch.rpm; \
   yum update -y; \
   yum install -y python-devel epel-release; \
-  yum install -y git tar bind-utils ansible \
+  yum install -y git tar gcc libffi-devel openssl-devel bind-utils ansible \
                  python-pip python-ceilometerclient \
                  python-cinderclient python-glanceclient \
                  python-heatclient python-neutronclient \
                  python-novaclient python-saharaclient \
                  python-swiftclient python-troveclient \
-                 python-openstackclient python-passlib; \
+                 python-openstackclient python-passlib \
+                 pyOpenSSL; \
   yum clean all; \
   pip install shade
 


### PR DESCRIPTION
#### What does this PR do?
Makes repo and package updates to be compatible with OpenStack 9 and the latest openshift-ansible changes.

#### How should this be manually tested?
Run `docker/openstack-client-centos/run.sh` and see that you can run through a provisioning job

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
/cc @oybed @sabre1041 @JayKayy 