### PR TITLE
Changing default openstack config directory to be inline with standar…

### DIFF
--- a/docker/openstack-client-centos/bin/start.sh
+++ b/docker/openstack-client-centos/bin/start.sh
@@ -4,7 +4,7 @@
 
 SSH_DIR=/root/.ssh
 INPUT_SSH_DIR=/mnt/.ssh
-CONFIG_DIR=/root/.openstack
+CONFIG_DIR=/root/.config/openstack
 
 # Copy mounted .ssh directory to ~/.ssh
 if [ -d $INPUT_SSH_DIR ]; then

--- a/docker/openstack-client-centos/run.sh
+++ b/docker/openstack-client-centos/run.sh
@@ -4,7 +4,7 @@
 
 
 SCRIPT_BASE_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-OPENSTACK_CONFIG_DIR=~/.openstack/
+OPENSTACK_CONFIG_DIR=~/.config/openstack/
 OPENSTACK_CLIENT_IMAGE="rhtconsulting/rhc-openstack-client"
 SSH_DIR=~/.ssh
 REMOVE_CONTAINER_ON_EXIT="--rm"
@@ -16,7 +16,7 @@ usage() {
     echo "
      Usage: $0 [options]
      Options:
-     --configdir=<configdir>       : Directory containing Openstack configuration files (Default: ~/.openstack/)
+     --configdir=<configdir>       : Directory containing Openstack configuration files (Default: ~/.config/openstack/)
      --image-name=<name>           : Name of the image to build or use (Default: rhtconsulting/rhc-openstack-client)
      --keep                        : Whether to keep the the container after exiting
      --ssh=<ssh>                   : Location of SSH keys to mount into the container (Default: ~/.ssh)
@@ -120,5 +120,5 @@ fi
 
 echo "Starting OpenStack Client Container...."
 echo
-#docker run -it ${HOST_NET} ${REMOVE_CONTAINER_ON_EXIT} -v ${OPENSTACK_CONFIG_DIR}:/root/.openstack:z ${REPOSITORY_VOLUME} ${SSH_VOLUME} ${ANSIBLE_CFG} ${OPENSTACK_CLIENT_IMAGE}
-docker run -it ${HOST_NET} ${REMOVE_CONTAINER_ON_EXIT} -v ${OPENSTACK_CONFIG_DIR}:/root/.openstack ${REPOSITORY_VOLUME} ${SSH_VOLUME} ${ANSIBLE_CFG} ${OPENSTACK_CLIENT_IMAGE}
+#docker run -it ${HOST_NET} ${REMOVE_CONTAINER_ON_EXIT} -v ${OPENSTACK_CONFIG_DIR}:/root/.config/openstack:z ${REPOSITORY_VOLUME} ${SSH_VOLUME} ${ANSIBLE_CFG} ${OPENSTACK_CLIENT_IMAGE}
+docker run -it ${HOST_NET} ${REMOVE_CONTAINER_ON_EXIT} -v ${OPENSTACK_CONFIG_DIR}:/root/.config/openstack ${REPOSITORY_VOLUME} ${SSH_VOLUME} ${ANSIBLE_CFG} ${OPENSTACK_CLIENT_IMAGE}


### PR DESCRIPTION
#### What does this PR do?
The new standard openstack client config directory is located at `~/.config/openstack`. As such I thought it would be appropriate to move the default directory we search in for openrc.sh files for openstack auth.

#### How should this be manually tested?
1. move local `~/.openstack` directory to `~/.config/openstack`
2. Rebuild docker image with docker/openstack-client-centos/run.sh
3. Check that openrc.sh files are now mounted to ~/.config/openstack, and that all of your `OS_*` environment variables still load, and that you can authenticate with openstack api (i.e. `openstack server list`)

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
/cc @oybed @sabre1041 

…d directory name