### PR TITLE
Adding oc client to dockerfile for running post-install provisioning

### DIFF
--- a/docker/openstack-client-centos/Dockerfile
+++ b/docker/openstack-client-centos/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Andrew Block “andrew.block@redhat.com”
 ADD bin/start.sh /root/
 
 # Update System and install clients
-RUN yum install -y https://repos.fedorapeople.org/repos/openstack/openstack-mitaka/rdo-release-mitaka-6.noarch.rpm; \
+RUN yum install -y --setopt=tsflags=nodocs https://repos.fedorapeople.org/repos/openstack/openstack-mitaka/rdo-release-mitaka-6.noarch.rpm centos-release-openshift-origin; \
   yum update -y; \
   yum install -y python-devel epel-release; \
   yum install -y git tar gcc libffi-devel openssl-devel bind-utils ansible \
@@ -15,7 +15,8 @@ RUN yum install -y https://repos.fedorapeople.org/repos/openstack/openstack-mita
                  python-novaclient python-saharaclient \
                  python-swiftclient python-troveclient \
                  python-openstackclient python-passlib \
-                 pyOpenSSL; \
+                 pyOpenSSL \
+                 origin-clients; \
   yum clean all; \
   pip install shade
 


### PR DESCRIPTION
#### What does this PR do?
See above

#### How should this be manually tested?
Start docker container with run script, and try running an `oc` command

```
./docker/openstack-client-centos/run.sh --repository=/home/esauer/src/
oc login
```

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
/cc @sabre1041 @oybed 

