### PR TITLE
* helper_functions.py --> set ETCD to a warning only if it is not a m…

### DIFF
--- a/solutions/validation/helper_functions.py
+++ b/solutions/validation/helper_functions.py
@@ -72,7 +72,7 @@ class DictionaryHandling:
                 previous_heading = server_name
                 # All dictionaries should have either True or False in order to be colourized
                 # True will be coloured Green, False will be Red. Anything else will be highlighted
-                if "False" in value:
+                if "False" in value or "None" in value:
                     print(textColors.FAIL),
                 elif "docker" in heading.lower():
                     print(textColors.WARNING),

--- a/solutions/validation/helper_functions.py
+++ b/solutions/validation/helper_functions.py
@@ -48,6 +48,10 @@ class DictionaryHandling:
 
     @staticmethod
     def format_output(text_to_print):
+        # Generally if something is False, I want it to be a RED error, but the below list includes headings which
+        # are not fatal, and should be treated as warnings only
+        warning_heading_list = ["ETCD", "Docker Running", "Docker Enabled", "sum", "available"]
+
         # This is a hack because I am assuming I have nothing outside of the stdlib available
         longest_line = 0
         for line in text_to_print.split("\n"):
@@ -73,16 +77,18 @@ class DictionaryHandling:
                 # All dictionaries should have either True or False in order to be colourized
                 # True will be coloured Green, False will be Red. Anything else will be highlighted
                 if "False" in value or "None" in value:
-                    print(textColors.FAIL),
-                elif "docker" in heading.lower():
-                    print(textColors.WARNING),
-                elif "True" in value:
-                    print(textColors.OKGREEN),
+                    if any(word in heading for word in warning_heading_list):
+                        print(textColors.WARNING),
+                    else:
+                        print(textColors.FAIL),
+                elif "True" in value or "on" in value:
+                    if "docker-storage" in heading:
+                        print(textColors.WARNING),
+                    else:
+                        print(textColors.OKGREEN),
                 # If the file has been modified mark it yellow as we cannot know whether it is correctly
                 # modified or not
-                elif "sum" in heading:
-                    print(textColors.WARNING),
-                elif "available" in heading:
+                elif any(word in heading for word in warning_heading_list) or "off" in value:
                     print(textColors.WARNING),
                 print("\t\t" + heading + "\t" + value)
                 print(textColors.ENDC),

--- a/solutions/validation/validate-pre-install.py
+++ b/solutions/validation/validate-pre-install.py
@@ -63,8 +63,12 @@ if options.openshift_version:
         openshift_server_repo = "rhel-7-server-ose-3.1-rpms"
     elif "3.3" in options.openshift_version:
         openshift_server_repo ="rhel-7-server-ose-3.3-rpms"
+    elif "3.4" in options.openshift_version:
+        openshift_server_repo ="rhel-7-server-ose-3.4-rpms"
+    elif "3.5" in options.openshift_version:
+        openshift_server_repo ="rhel-7-server-ose-3.5-rpms"
 else:
-    openshift_server_repo = "rhel-7-server-ose-3.3-rpms"
+    openshift_server_repo = "rhel-7-server-ose-3.4-rpms"
 ose_repos = ["rhel-7-server-rpms", "rhel-7-server-extras-rpms", openshift_server_repo]
 ose_required_packages_list = ["wget", "git", "net-tools", "bind-utils", "iptables-services", "bridge-utils",
                               "bash-completion", "atomic-openshift-utils", "docker"]


### PR DESCRIPTION
#### What does this PR do?
This addresses https://github.com/rhtconsulting/rhc-ose/issues/245

* validate-pre-install.py --> added hashes for different versions of docker
* validate-pre-install.py --> added check to see if ETCD is a partition
* validate-pre-install.py --> added flags for 'private-registry'

#### How should this be manually tested?
```./validate_pre-install.py` --ansible-host-file=/etc/ansible/hosts --show-sha-sums=yes --ansible-ssh-user=root --openshift-version=3.3 --private-registry```

The --private-registry is optional. If it is not set, the script does not check the sum of `/etc/sysconfig/docker` anymore as it is no longer necessary to modify this file by hand in the default configuration

#### Who would you like to review this?
/cc @etsauer  @oybed 
